### PR TITLE
support_19086_dockerfile_multistage_build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,21 @@
+FROM maven:ibmjava-alpine
+
+WORKDIR /project
+
+# Cache maven dependencies
+ADD pom.xml /project
+RUN mvn clean install -Dmaven.test.skip=true -Dspring-boot.repackage.skip
+
+# Stage 1: build jar
+ADD . /project
+# Integration Tests will be skipped as they require a database
+RUN mvn test
+RUN mvn clean install -Dmaven.test.skip=true
+
+# Stage 2: extract jar and set entrypoint
 FROM openjdk:8-jre-slim
 RUN useradd -s /bin/bash user
 USER user
-COPY --chown=644 target/agent-api-*.jar /agent-api.jar
+COPY --from=0 --chown=644 /project/target/agent-api-*.jar /agent-api.jar
 EXPOSE 8080
 ENTRYPOINT ["java","-XX:+UnlockExperimentalVMOptions","-XX:+UseCGroupMemoryLimitForHeap","-jar","/agent-api.jar"]


### PR DESCRIPTION
Adjust dockerfile for multi stage build as done in the object store.

- first step caches dependencies
- second step builds the jar and run tests
- third step extracts jar for final image