### PR TITLE
19103 review unique constraints

### DIFF
--- a/src/main/java/ca/gc/aafc/agent/api/entities/Agent.java
+++ b/src/main/java/ca/gc/aafc/agent/api/entities/Agent.java
@@ -41,7 +41,7 @@ public class Agent {
 
   @NaturalId
   @NotNull
-  @Column(name = "uuid")
+  @Column(name = "uuid", unique = true)
   private UUID uuid;
 
   @NotBlank


### PR DESCRIPTION
Re-introduced `unique=true` parameter for uuid attribute.  Should not have been removed.