### PR TITLE
19418 add created by and created on

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <hibernate-types-52.version>2.9.5</hibernate-types-52.version>
     <rsql-jpa.version>2.0.2</rsql-jpa.version>
     <crnk.version>3.2.20200318095228</crnk.version>
-    <dina-base-api.version>0.27</dina-base-api.version>
+    <dina-base-api.version>0.28</dina-base-api.version>
   </properties>
   <repositories>
     <!-- Required for Crnk 3.0 -->

--- a/src/main/java/ca/gc/aafc/agent/api/dto/AgentDto.java
+++ b/src/main/java/ca/gc/aafc/agent/api/dto/AgentDto.java
@@ -1,5 +1,6 @@
 package ca.gc.aafc.agent.api.dto;
 
+import java.time.OffsetDateTime;
 import java.util.UUID;
 
 import ca.gc.aafc.agent.api.entities.Agent;
@@ -20,5 +21,6 @@ public class AgentDto {
 
   private String displayName;
   private String email;
-
+  private String createdBy;
+  private OffsetDateTime createdOn;
 }

--- a/src/main/java/ca/gc/aafc/agent/api/entities/Agent.java
+++ b/src/main/java/ca/gc/aafc/agent/api/entities/Agent.java
@@ -14,8 +14,6 @@ import javax.validation.constraints.NotNull;
 
 import org.hibernate.annotations.NaturalId;
 import org.hibernate.annotations.NaturalIdCache;
-import org.keycloak.adapters.springsecurity.token.KeycloakAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
 
 import ca.gc.aafc.dina.entity.DinaEntity;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;

--- a/src/main/java/ca/gc/aafc/agent/api/entities/Agent.java
+++ b/src/main/java/ca/gc/aafc/agent/api/entities/Agent.java
@@ -14,6 +14,8 @@ import javax.validation.constraints.NotNull;
 
 import org.hibernate.annotations.NaturalId;
 import org.hibernate.annotations.NaturalIdCache;
+import org.keycloak.adapters.springsecurity.token.KeycloakAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import ca.gc.aafc.dina.entity.DinaEntity;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -62,6 +64,13 @@ public class Agent implements DinaEntity {
   @PrePersist
   public void initUuid() {
     this.uuid = UUID.randomUUID();
+
+    KeycloakAuthenticationToken token =
+        (KeycloakAuthenticationToken) SecurityContextHolder.getContext().getAuthentication();
+
+    if (token != null) {
+      this.createdBy = token.getName();
+    }
   }
 
 }

--- a/src/main/java/ca/gc/aafc/agent/api/entities/Agent.java
+++ b/src/main/java/ca/gc/aafc/agent/api/entities/Agent.java
@@ -52,7 +52,6 @@ public class Agent implements DinaEntity {
   @NotBlank
   private String email;
 
-  @NotBlank
   @Column(name = "created_by")
   private String createdBy;
 

--- a/src/main/java/ca/gc/aafc/agent/api/entities/Agent.java
+++ b/src/main/java/ca/gc/aafc/agent/api/entities/Agent.java
@@ -1,5 +1,6 @@
 package ca.gc.aafc.agent.api.entities;
 
+import java.time.OffsetDateTime;
 import java.util.UUID;
 
 import javax.persistence.Column;
@@ -50,6 +51,14 @@ public class Agent implements DinaEntity {
 
   @NotBlank
   private String email;
+
+  @NotBlank
+  @Column(name = "created_by")
+  private String createdBy;
+
+
+  @Column(name = "created_on", insertable = false, updatable = false)
+  private OffsetDateTime createdOn;
 
   @PrePersist
   public void initUuid() {

--- a/src/main/java/ca/gc/aafc/agent/api/entities/Agent.java
+++ b/src/main/java/ca/gc/aafc/agent/api/entities/Agent.java
@@ -64,13 +64,6 @@ public class Agent implements DinaEntity {
   @PrePersist
   public void initUuid() {
     this.uuid = UUID.randomUUID();
-
-    KeycloakAuthenticationToken token =
-        (KeycloakAuthenticationToken) SecurityContextHolder.getContext().getAuthentication();
-
-    if (token != null) {
-      this.createdBy = token.getName();
-    }
   }
 
 }

--- a/src/main/java/ca/gc/aafc/agent/api/repository/AgentResourceRepository.java
+++ b/src/main/java/ca/gc/aafc/agent/api/repository/AgentResourceRepository.java
@@ -1,8 +1,8 @@
 package ca.gc.aafc.agent.api.repository;
 
 import java.util.Arrays;
+import java.util.Optional;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
 import ca.gc.aafc.agent.api.dto.AgentDto;
@@ -16,14 +16,15 @@ import ca.gc.aafc.dina.security.DinaAuthenticatedUser;
 @Repository
 public class AgentResourceRepository extends JpaResourceRepository<AgentDto> {
 
-  @Autowired(required = false) // Bean does not exist with keycloak disabled.
-  private DinaAuthenticatedUser authenticatedUser;
+  // Bean does not exist with keycloak disabled.
+  private Optional<DinaAuthenticatedUser> authenticatedUser;
 
   public AgentResourceRepository(
     JpaDtoRepository dtoRepository,
     SimpleFilterHandler simpleFilterHandler,
     RsqlFilterHandler rsqlFilterHandler,
-    JpaMetaInformationProvider metaInformationProvider
+    JpaMetaInformationProvider metaInformationProvider,
+    Optional<DinaAuthenticatedUser> authenticatedUser
   ) {
     super(
       AgentDto.class,
@@ -31,12 +32,13 @@ public class AgentResourceRepository extends JpaResourceRepository<AgentDto> {
       Arrays.asList(simpleFilterHandler, rsqlFilterHandler),
       metaInformationProvider
     );
+    this.authenticatedUser = authenticatedUser;
   }
 
   @Override
   public <S extends AgentDto> S create(S resource) {
-    if (authenticatedUser != null) {
-      resource.setCreatedBy(authenticatedUser.getUsername());
+    if (authenticatedUser.isPresent()) {
+      resource.setCreatedBy(authenticatedUser.get().getUsername());
     }
     return super.create(resource);
   }

--- a/src/main/java/ca/gc/aafc/agent/api/repository/AgentResourceRepository.java
+++ b/src/main/java/ca/gc/aafc/agent/api/repository/AgentResourceRepository.java
@@ -10,15 +10,19 @@ import ca.gc.aafc.dina.filter.SimpleFilterHandler;
 import ca.gc.aafc.dina.repository.JpaDtoRepository;
 import ca.gc.aafc.dina.repository.JpaResourceRepository;
 import ca.gc.aafc.dina.repository.meta.JpaMetaInformationProvider;
+import ca.gc.aafc.dina.security.DinaAuthenticatedUser;
 
 @Repository
 public class AgentResourceRepository extends JpaResourceRepository<AgentDto> {
+
+  private DinaAuthenticatedUser authenticatedUser;
 
   public AgentResourceRepository(
     JpaDtoRepository dtoRepository,
     SimpleFilterHandler simpleFilterHandler,
     RsqlFilterHandler rsqlFilterHandler,
-    JpaMetaInformationProvider metaInformationProvider
+    JpaMetaInformationProvider metaInformationProvider,
+    DinaAuthenticatedUser authenticatedUser
   ) {
     super(
       AgentDto.class,
@@ -26,6 +30,13 @@ public class AgentResourceRepository extends JpaResourceRepository<AgentDto> {
       Arrays.asList(simpleFilterHandler, rsqlFilterHandler),
       metaInformationProvider
     );
+    this.authenticatedUser = authenticatedUser;
+  }
+
+  @Override
+  public <S extends AgentDto> S create(S resource) {
+    resource.setCreatedBy(authenticatedUser.getUsername());
+    return super.create(resource);
   }
 
 }

--- a/src/main/java/ca/gc/aafc/agent/api/repository/AgentResourceRepository.java
+++ b/src/main/java/ca/gc/aafc/agent/api/repository/AgentResourceRepository.java
@@ -2,6 +2,7 @@ package ca.gc.aafc.agent.api.repository;
 
 import java.util.Arrays;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
 import ca.gc.aafc.agent.api.dto.AgentDto;
@@ -15,14 +16,14 @@ import ca.gc.aafc.dina.security.DinaAuthenticatedUser;
 @Repository
 public class AgentResourceRepository extends JpaResourceRepository<AgentDto> {
 
+  @Autowired(required = false) // Bean does not exist with keycloak disabled.
   private DinaAuthenticatedUser authenticatedUser;
 
   public AgentResourceRepository(
     JpaDtoRepository dtoRepository,
     SimpleFilterHandler simpleFilterHandler,
     RsqlFilterHandler rsqlFilterHandler,
-    JpaMetaInformationProvider metaInformationProvider,
-    DinaAuthenticatedUser authenticatedUser
+    JpaMetaInformationProvider metaInformationProvider
   ) {
     super(
       AgentDto.class,
@@ -30,12 +31,13 @@ public class AgentResourceRepository extends JpaResourceRepository<AgentDto> {
       Arrays.asList(simpleFilterHandler, rsqlFilterHandler),
       metaInformationProvider
     );
-    this.authenticatedUser = authenticatedUser;
   }
 
   @Override
   public <S extends AgentDto> S create(S resource) {
-    resource.setCreatedBy(authenticatedUser.getUsername());
+    if (authenticatedUser != null) {
+      resource.setCreatedBy(authenticatedUser.getUsername());
+    }
     return super.create(resource);
   }
 

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -1,4 +1,5 @@
 <?xml version="1.1" encoding="UTF-8" standalone="no"?>
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
   <include file="db/changelog/db.changelog-init.xml"/>
+  <include file="db/changelog/migrations/1-Add_CreatedBy_and_CreatedOn_agent_table.xml" />
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/migrations/1-Add_CreatedBy_and_CreatedOn_agent_table.xml
+++ b/src/main/resources/db/changelog/migrations/1-Add_CreatedBy_and_CreatedOn_agent_table.xml
@@ -1,0 +1,18 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no" ?>
+<databaseChangeLog 
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd"
+  context="schema-change">
+
+  <changeSet context="schema-change" id="1-Add_CreatedBy_and_CreatedOn_agent_table" author="jonathan Keyuk">
+
+    <addColumn tableName="agent">
+      <column name="created_by" type="varchar(255)" />
+      <column name="created_on" type="timestamp " />
+    </addColumn>
+
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/migrations/1-Add_CreatedBy_and_CreatedOn_agent_table.xml
+++ b/src/main/resources/db/changelog/migrations/1-Add_CreatedBy_and_CreatedOn_agent_table.xml
@@ -12,9 +12,7 @@
       <column name="created_by" type="varchar(255)">
         <constraints nullable="false" />
       </column>
-      <column name="created_on" type="timestamptz">
-        <constraints nullable="false" />
-      </column>
+      <column name="created_on" type="timestamptz" defaultValueComputed="current_timestamp"/>
     </addColumn>
 
   </changeSet>

--- a/src/main/resources/db/changelog/migrations/1-Add_CreatedBy_and_CreatedOn_agent_table.xml
+++ b/src/main/resources/db/changelog/migrations/1-Add_CreatedBy_and_CreatedOn_agent_table.xml
@@ -9,9 +9,7 @@
   <changeSet context="schema-change" id="1-Add_CreatedBy_and_CreatedOn_agent_table" author="jonathan Keyuk">
 
     <addColumn tableName="agent">
-      <column name="created_by" type="varchar(255)">
-        <constraints nullable="false" />
-      </column>
+      <column name="created_by" type="varchar(255)"/>
       <column name="created_on" type="timestamptz" defaultValueComputed="current_timestamp"/>
     </addColumn>
 

--- a/src/main/resources/db/changelog/migrations/1-Add_CreatedBy_and_CreatedOn_agent_table.xml
+++ b/src/main/resources/db/changelog/migrations/1-Add_CreatedBy_and_CreatedOn_agent_table.xml
@@ -9,8 +9,12 @@
   <changeSet context="schema-change" id="1-Add_CreatedBy_and_CreatedOn_agent_table" author="jonathan Keyuk">
 
     <addColumn tableName="agent">
-      <column name="created_by" type="varchar(255)" />
-      <column name="created_on" type="timestamp " />
+      <column name="created_by" type="varchar(255)">
+        <constraints nullable="false" />
+      </column>
+      <column name="created_on" type="timestamptz">
+        <constraints nullable="false" />
+      </column>
     </addColumn>
 
   </changeSet>

--- a/src/test/java/ca/gc/aafc/agent/api/AgentRestJsonIT.java
+++ b/src/test/java/ca/gc/aafc/agent/api/AgentRestJsonIT.java
@@ -42,7 +42,6 @@ import lombok.extern.log4j.Log4j2;
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Transactional
-@ActiveProfiles("test")
 @Log4j2
 public class AgentRestJsonIT extends DBBackedIntegrationTest {
 

--- a/src/test/java/ca/gc/aafc/agent/api/AgentRestJsonIT.java
+++ b/src/test/java/ca/gc/aafc/agent/api/AgentRestJsonIT.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import com.google.common.collect.ImmutableMap;

--- a/src/test/java/ca/gc/aafc/agent/api/KeycloakTestConfiguration.java
+++ b/src/test/java/ca/gc/aafc/agent/api/KeycloakTestConfiguration.java
@@ -11,10 +11,11 @@ import ca.gc.aafc.dina.security.DinaAuthenticatedUser;
  */
 @Configuration
 public class KeycloakTestConfiguration {
+  public static final String USER_NAME = "test_user";
   @Bean
   public DinaAuthenticatedUser dinaAuthenticatedUser() {
     DinaAuthenticatedUser testUser = DinaAuthenticatedUser.builder()
-    .username("test_user")
+    .username(USER_NAME)
     .build();
     return testUser;
   }

--- a/src/test/java/ca/gc/aafc/agent/api/KeycloakTestConfiguration.java
+++ b/src/test/java/ca/gc/aafc/agent/api/KeycloakTestConfiguration.java
@@ -1,0 +1,21 @@
+package ca.gc.aafc.agent.api;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import ca.gc.aafc.dina.security.DinaAuthenticatedUser;
+
+/**
+ * Configuration class used to provide a test instance of {@link DinaAuthenticatedUser}.
+ * Keycloak should be disabled in order to use the configuration.
+ */
+@Configuration
+public class KeycloakTestConfiguration {
+  @Bean
+  public DinaAuthenticatedUser dinaAuthenticatedUser() {
+    DinaAuthenticatedUser testUser = DinaAuthenticatedUser.builder()
+    .username("test_user")
+    .build();
+    return testUser;
+  }
+}

--- a/src/test/java/ca/gc/aafc/agent/api/entities/AgentCrudIT.java
+++ b/src/test/java/ca/gc/aafc/agent/api/entities/AgentCrudIT.java
@@ -8,11 +8,7 @@ import javax.transaction.Transactional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.keycloak.adapters.springsecurity.token.KeycloakAuthenticationToken;
-import org.mockito.Answers;
-import org.mockito.Mockito;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
 
 import ca.gc.aafc.agent.api.testsupport.factories.AgentFactory;
@@ -21,7 +17,7 @@ import ca.gc.aafc.dina.testsupport.DBBackedIntegrationTest;
 /**
  * Test suite to validate {@link Agent} performs as a valid Hibernate Entity.
  */
-@SpringBootTest(properties = "keycloak.enabled: true")
+@SpringBootTest
 @Transactional
 @ActiveProfiles("test")
 public class AgentCrudIT extends DBBackedIntegrationTest {
@@ -40,26 +36,6 @@ public class AgentCrudIT extends DBBackedIntegrationTest {
     assertNull(agent.getId());
     save(agent);
     assertNotNull(agent.getId());
-  }
-
-  @Test
-  public void save_KeyCloakUserEnabled_SetsCreatedBy() {
-    KeycloakAuthenticationToken mockToken =
-        Mockito.mock(KeycloakAuthenticationToken.class, Answers.RETURNS_DEEP_STUBS);
-
-    // Mock the needed fields on the keycloak token:
-    Mockito.when(mockToken.getName()).thenReturn("test-user");
-    Mockito.when(mockToken.getAccount().getKeycloakSecurityContext().getToken().getOtherClaims()
-        .get("agent-identifier")).thenReturn("a2cef694-10f1-42ec-b403-e0f8ae9d2ae6");
-
-    SecurityContextHolder.getContext().setAuthentication(mockToken);
-
-    Agent agent = AgentFactory.newAgent().build();
-    save(agent);
-
-    Agent fetchedAgent = find(Agent.class, agent.getId());
-    assertNotNull(fetchedAgent.getCreatedBy());
-    assertEquals(mockToken.getName(), fetchedAgent.getCreatedBy());
   }
 
   @Test

--- a/src/test/java/ca/gc/aafc/agent/api/entities/AgentCrudIT.java
+++ b/src/test/java/ca/gc/aafc/agent/api/entities/AgentCrudIT.java
@@ -45,6 +45,7 @@ public class AgentCrudIT extends DBBackedIntegrationTest {
     assertEquals(agentUnderTest.getDisplayName(), fetchedAgent.getDisplayName());
     assertEquals(agentUnderTest.getEmail(), fetchedAgent.getEmail());
     assertEquals(agentUnderTest.getUuid(), fetchedAgent.getUuid());
+    assertNotNull(fetchedAgent.getCreatedOn());
   }
 
   @Test

--- a/src/test/java/ca/gc/aafc/agent/api/entities/AgentCrudIT.java
+++ b/src/test/java/ca/gc/aafc/agent/api/entities/AgentCrudIT.java
@@ -8,7 +8,11 @@ import javax.transaction.Transactional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.keycloak.adapters.springsecurity.token.KeycloakAuthenticationToken;
+import org.mockito.Answers;
+import org.mockito.Mockito;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
 
 import ca.gc.aafc.agent.api.testsupport.factories.AgentFactory;
@@ -17,7 +21,7 @@ import ca.gc.aafc.dina.testsupport.DBBackedIntegrationTest;
 /**
  * Test suite to validate {@link Agent} performs as a valid Hibernate Entity.
  */
-@SpringBootTest
+@SpringBootTest(properties = "keycloak.enabled: true")
 @Transactional
 @ActiveProfiles("test")
 public class AgentCrudIT extends DBBackedIntegrationTest {
@@ -36,6 +40,26 @@ public class AgentCrudIT extends DBBackedIntegrationTest {
     assertNull(agent.getId());
     save(agent);
     assertNotNull(agent.getId());
+  }
+
+  @Test
+  public void save_KeyCloakUserEnabled_SetsCreatedBy() {
+    KeycloakAuthenticationToken mockToken =
+        Mockito.mock(KeycloakAuthenticationToken.class, Answers.RETURNS_DEEP_STUBS);
+
+    // Mock the needed fields on the keycloak token:
+    Mockito.when(mockToken.getName()).thenReturn("test-user");
+    Mockito.when(mockToken.getAccount().getKeycloakSecurityContext().getToken().getOtherClaims()
+        .get("agent-identifier")).thenReturn("a2cef694-10f1-42ec-b403-e0f8ae9d2ae6");
+
+    SecurityContextHolder.getContext().setAuthentication(mockToken);
+
+    Agent agent = AgentFactory.newAgent().build();
+    save(agent);
+
+    Agent fetchedAgent = find(Agent.class, agent.getId());
+    assertNotNull(fetchedAgent.getCreatedBy());
+    assertEquals(mockToken.getName(), fetchedAgent.getCreatedBy());
   }
 
   @Test

--- a/src/test/java/ca/gc/aafc/agent/api/repository/AgentResourceRepositoryIT.java
+++ b/src/test/java/ca/gc/aafc/agent/api/repository/AgentResourceRepositoryIT.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import ca.gc.aafc.agent.api.dto.AgentDto;
@@ -30,7 +29,6 @@ import io.crnk.core.queryspec.QuerySpec;
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
 @Transactional
-@ActiveProfiles("test")
 public class AgentResourceRepositoryIT extends DBBackedIntegrationTest {
 
   @Inject

--- a/src/test/java/ca/gc/aafc/agent/api/repository/AgentResourceRepositoryIT.java
+++ b/src/test/java/ca/gc/aafc/agent/api/repository/AgentResourceRepositoryIT.java
@@ -1,8 +1,8 @@
 package ca.gc.aafc.agent.api.repository;
 
+import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.UUID;
 
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import ca.gc.aafc.agent.api.KeycloakTestConfiguration;
 import ca.gc.aafc.agent.api.dto.AgentDto;
 import ca.gc.aafc.agent.api.entities.Agent;
 import ca.gc.aafc.agent.api.testsupport.factories.AgentFactory;
@@ -54,6 +55,7 @@ public class AgentResourceRepositoryIT extends DBBackedIntegrationTest {
     assertEquals(agentDto.getDisplayName(), result.getDisplayName());
     assertEquals(agentDto.getEmail(), result.getEmail());
     assertEquals(uuid, result.getUuid());
+    assertEquals(KeycloakTestConfiguration.USER_NAME, result.getCreatedBy());
   }
 
   @Test


### PR DESCRIPTION
Creates two new columns for the agent table:
- created by (Name of the keycloak agent sending the request)
- created on (Time stamp of the request)

Created on field is automatically set upon the creation of a agent.