### PR TITLE
19115 get with invalid UUID should return 400

### DIFF
--- a/src/main/java/ca/gc/aafc/agent/api/MainConfiguration.java
+++ b/src/main/java/ca/gc/aafc/agent/api/MainConfiguration.java
@@ -49,7 +49,7 @@ public class MainConfiguration {
 
   @Bean
   public RequestUuidValidationFilter idValidator() {
-    return new RequestUuidValidationFilter(Arrays.asList("person"));
+    return new RequestUuidValidationFilter("/api/v1", Arrays.asList("person"));
   }
 
 }

--- a/src/main/java/ca/gc/aafc/agent/api/MainConfiguration.java
+++ b/src/main/java/ca/gc/aafc/agent/api/MainConfiguration.java
@@ -1,5 +1,6 @@
 package ca.gc.aafc.agent.api;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -12,6 +13,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
 import ca.gc.aafc.agent.api.dto.PersonDto;
+import ca.gc.aafc.agent.api.repository.RequestUuidValidationFilter;
 import ca.gc.aafc.dina.DinaBaseApiAutoConfiguration;
 import ca.gc.aafc.dina.dto.RelatedEntity;
 import ca.gc.aafc.dina.jpa.BaseDAO;
@@ -43,6 +45,11 @@ public class MainConfiguration {
           clazz -> clazz.getAnnotation(RelatedEntity.class).value()));
 
     return new JpaDtoMapper(entitiesMap, customFieldResolvers);
+  }
+
+  @Bean
+  public RequestUuidValidationFilter idValidator() {
+    return new RequestUuidValidationFilter(Arrays.asList("person"));
   }
 
 }

--- a/src/main/java/ca/gc/aafc/agent/api/repository/RequestUuidValidationFilter.java
+++ b/src/main/java/ca/gc/aafc/agent/api/repository/RequestUuidValidationFilter.java
@@ -25,6 +25,9 @@ import lombok.NonNull;
 import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
 
+/**
+ * Filter to intercept HTTP requests and validate the id is a valid UUID.
+ */
 @Log4j2
 public class RequestUuidValidationFilter extends CrnkFilter {
 
@@ -72,11 +75,29 @@ public class RequestUuidValidationFilter extends CrnkFilter {
     super.doFilter(request, response, chain);
   }
 
+  /**
+   * Returns true if the given method is supported by this class. (given method is
+   * present in {@link RequestUuidValidationFilter#METHODS} )
+   * 
+   * @param method
+   *                 - HTTP method to validate
+   * @return
+   */
   private static boolean isValidMethod(String method) {
     return Arrays.asList(METHODS).stream()
         .anyMatch(elemment -> StringUtils.equalsIgnoreCase(method, elemment));
   }
 
+  /**
+   * Removes the pre-set web path prefix from the given uri.
+   * 
+   * @param uri
+   *              - uri to strip
+   * @throws -
+   *             {@link IllegalStateException} if the pre-set web path prefix does
+   *             not match the start of the uri.
+   * @return uri with web path prefix stripped
+   */
   private String stripPrefix(String uri) {
     if (!uri.startsWith(webPathPrefix)) {
       throw new IllegalStateException(
@@ -85,12 +106,27 @@ public class RequestUuidValidationFilter extends CrnkFilter {
     return uri.replaceFirst(webPathPrefix, "");
   }
 
+  /**
+   * Splits a given uri into an array of seperate parts.
+   *
+   * @param uri
+   *              - uri to split
+   * @return array of seperate URI parts
+   */
   private static String[] splitPath(String uri) {
     return Arrays.asList(uri.split(SEPARATOR)).stream()
         .filter(ele -> StringUtils.isNotBlank(ele))
         .toArray(String[]::new);
   }
 
+  /**
+   * Returns the endpoint of the given path if it is present in the pre-set list
+   * of endpoints. Endpoint should be the first element of the given path. (ex.
+   * /{endpoint}/{id}/...)
+   * 
+   * @param path
+   * @return
+   */
   private Optional<String> parseEndpoint(String[] path) {
     if (path.length == 0) {
       return Optional.empty();
@@ -98,6 +134,15 @@ public class RequestUuidValidationFilter extends CrnkFilter {
     return endpoints.stream().filter(end -> StringUtils.equalsIgnoreCase(end, path[0])).findFirst();
   }
 
+  /**
+   * Returns the id part of the given path or Optional empty if one is not
+   * present. ID should be the second element of the path. (ex.
+   * /{endpoint}/{id}/...)
+   *
+   * @param path
+   *               - path to parse
+   * @return
+   */
   private Optional<String> parseUUID(String[] path) {
     if (path.length < 2) {
       return Optional.empty();
@@ -105,6 +150,16 @@ public class RequestUuidValidationFilter extends CrnkFilter {
     return Optional.of(path[1]);
   }
 
+  /**
+   * Sets the given response to an error response for a given uuid and uri.
+   *
+   * @param resp
+   *               - response to set
+   * @param uuid
+   *               - uuid of the request
+   * @param uri
+   *               - uri of the requeest
+   */
   @SneakyThrows
   private static void setErrorResponse(HttpServletResponse resp, String uuid, String uri) {
     resp.setStatus(HttpStatus.BAD_REQUEST_400);
@@ -113,6 +168,16 @@ public class RequestUuidValidationFilter extends CrnkFilter {
     resp.flushBuffer();
   }
 
+  /**
+   * Returns a JSON string representing the body of the error message for a given
+   * uuid and uri.
+   *
+   * @param uuid
+   *               - uuid of the request
+   * @param uri
+   *               - uri of the request
+   * @return JSON string representing the body of the error message
+   */
   @SneakyThrows
   private static String getErrorBody(String uuid, String uri) {
     Map<String, String> metaData = ImmutableMap.of(
@@ -128,6 +193,13 @@ public class RequestUuidValidationFilter extends CrnkFilter {
     return JSON_MAPPER.writeValueAsString(returnBody);
   }
 
+  /**
+   * Returns true if the given string can be parsed as a UUID.
+   *
+   * @param uuid
+   *               - string to validate
+   * @return true if the given string can be parsed as a UUID
+   */
   private static boolean isUuidValid(String uuid) {
     try {
       UUID.fromString(uuid);

--- a/src/main/java/ca/gc/aafc/agent/api/repository/RequestUuidValidationFilter.java
+++ b/src/main/java/ca/gc/aafc/agent/api/repository/RequestUuidValidationFilter.java
@@ -23,7 +23,7 @@ import lombok.extern.log4j.Log4j2;
 @RequiredArgsConstructor
 public class RequestUuidValidationFilter extends CrnkFilter {
 
-  private static final String METHOD = "GET";
+  private static final String[] METHODS = {"GET", "PATCH"};
   private static final String SEPARATOR = "/";
 
   @NonNull
@@ -37,7 +37,7 @@ public class RequestUuidValidationFilter extends CrnkFilter {
       HttpServletRequest httpRequest = (HttpServletRequest) request;
       HttpServletResponse httpResponse = (HttpServletResponse) response;
 
-      if (StringUtils.equalsIgnoreCase(httpRequest.getMethod(), METHOD)) {
+      if (isValidMethod(httpRequest.getMethod())) {
         String uri = httpRequest.getRequestURI();
         log.info("Validating ID if present for URI: " + uri);
 
@@ -54,6 +54,11 @@ public class RequestUuidValidationFilter extends CrnkFilter {
       }
     }
     super.doFilter(request, response, chain);
+  }
+
+  private static boolean isValidMethod(String method) {
+    return Arrays.asList(METHODS).stream()
+        .anyMatch(elemment -> StringUtils.equalsIgnoreCase(method, elemment));
   }
 
   private static String[] splitPath(String uri) {

--- a/src/main/java/ca/gc/aafc/agent/api/repository/RequestUuidValidationFilter.java
+++ b/src/main/java/ca/gc/aafc/agent/api/repository/RequestUuidValidationFilter.java
@@ -1,0 +1,78 @@
+package ca.gc.aafc.agent.api.repository;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.UUID;
+
+import javax.inject.Named;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.lang3.StringUtils;
+
+import io.crnk.servlet.CrnkFilter;
+import lombok.extern.log4j.Log4j2;
+
+@Named
+@Log4j2
+public class RequestUuidValidationFilter extends CrnkFilter {
+
+  private static final String SEPARATOR = "/";
+  private static final String ENTITY_NAME = "person";
+
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+      throws IOException, ServletException {
+
+    if (request instanceof HttpServletRequest && response instanceof HttpServletResponse) {
+      HttpServletRequest httpRequest = (HttpServletRequest) request;
+      HttpServletResponse httpResponse = (HttpServletResponse) response;
+
+      if (StringUtils.equalsIgnoreCase(httpRequest.getMethod(), "GET")) {
+        log.info("Validating ID if present for URI: " + httpRequest.getRequestURI());
+
+        String[] path = splitPath(httpRequest.getRequestURI());
+
+        int index = indexOfIgnoreCase(path, ENTITY_NAME);
+
+        if (index < path.length && !isUuidValid(path[index + 1])) {
+          httpResponse.sendError(
+            HttpServletResponse.SC_BAD_REQUEST,
+            path[index + 1] + " is not a valid uuid");
+          return;
+        }
+      }
+    }
+    super.doFilter(request, response, chain);
+  }
+
+  private static String[] splitPath(String uri) {
+    String[] path = uri.split(SEPARATOR);
+    return Arrays.asList(path).stream().filter(ele -> StringUtils.isNotBlank(ele))
+        .toArray(String[]::new);
+  }
+
+  private static int indexOfIgnoreCase(String[] array, String string) {
+    for (int i = 0; i < array.length; i++) {
+      String ele = array[i];
+      if (StringUtils.equalsIgnoreCase(ele, string)) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  private static boolean isUuidValid(String uuid) {
+    try {
+      UUID.fromString(uuid);
+      return true;
+    } catch (IllegalArgumentException e) {
+      log.warn("{} is not a valid uuid", () -> uuid);
+      return false;
+    }
+  }
+}

--- a/src/main/java/ca/gc/aafc/agent/api/repository/RequestUuidValidationFilter.java
+++ b/src/main/java/ca/gc/aafc/agent/api/repository/RequestUuidValidationFilter.java
@@ -52,9 +52,11 @@ public class RequestUuidValidationFilter extends CrnkFilter {
         Optional<String> endpoint = parseEndpoint(path);
 
         String endOfPath = path[path.length - 1];
-        if (endpoint.isPresent() && hasId(path, endpoint.get()) && !isUuidValid(endOfPath)) {
-          setErrorResponse(httpResponse, endOfPath, uri);
-          return;
+        if (endpoint.isPresent()) {
+          if (hasId(path, endpoint.get()) && !isUuidValid(endOfPath)) {
+            setErrorResponse(httpResponse, endOfPath, uri);
+            return;
+          }
         } else {
           log.warn("UUID validation not set for resouce with URI: " + uri);
         }

--- a/src/main/java/ca/gc/aafc/agent/api/repository/RequestUuidValidationFilter.java
+++ b/src/main/java/ca/gc/aafc/agent/api/repository/RequestUuidValidationFilter.java
@@ -30,7 +30,7 @@ import lombok.extern.log4j.Log4j2;
 @RequiredArgsConstructor
 public class RequestUuidValidationFilter extends CrnkFilter {
 
-  private static final String[] METHODS = {"GET", "PATCH"};
+  private static final String[] METHODS = {"GET", "PATCH", "DELETE"};
   private static final String SEPARATOR = "/";
 
   @NonNull

--- a/src/main/java/ca/gc/aafc/agent/api/repository/RequestUuidValidationFilter.java
+++ b/src/main/java/ca/gc/aafc/agent/api/repository/RequestUuidValidationFilter.java
@@ -32,6 +32,7 @@ public class RequestUuidValidationFilter extends CrnkFilter {
 
   private static final String[] METHODS = {"GET", "PATCH", "DELETE"};
   private static final String SEPARATOR = "/";
+  private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
 
   @NonNull
   private final List<String> endpoints;
@@ -106,7 +107,7 @@ public class RequestUuidValidationFilter extends CrnkFilter {
       "detail", uuid + " is not a valid uuid",
       "meta", metaData);
     Map<String, Object[]> returnBody = ImmutableMap.of("errors", new Object[] { errorData });
-    return new ObjectMapper().writeValueAsString(returnBody);
+    return JSON_MAPPER.writeValueAsString(returnBody);
   }
 
   private static boolean isUuidValid(String uuid) {

--- a/src/test/java/ca/gc/aafc/agent/api/PersonRestJsonIT.java
+++ b/src/test/java/ca/gc/aafc/agent/api/PersonRestJsonIT.java
@@ -17,6 +17,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -125,14 +127,13 @@ public class PersonRestJsonIT extends DBBackedIntegrationTest {
     response.then().statusCode(HttpStatus.NOT_FOUND_404);
   }
 
-  @Test
-  public void get_InvalidUUID_ReturnsBadRequest() {
-    Response getResponse = sendGet("12131231");
+  @ParameterizedTest
+  @ValueSource(strings = { 
+    "12131231",
+    "12131231?filter[acDerivedFrom.id][EQ]=a8098c1a-f86e-11da-bd1a-00112444be1e" })
+  public void get_InvalidUUID_ReturnsBadRequest(String uri) {
+    Response getResponse = sendGet(uri);
     getResponse.then().statusCode(HttpStatus.BAD_REQUEST_400);
-
-    Response getWithQueryString = sendGet("12131231"+
-    "?filter[acDerivedFrom.id][EQ]=a8098c1a-f86e-11da-bd1a-00112444be1e");
-    getWithQueryString.then().statusCode(HttpStatus.BAD_REQUEST_400);
   }
 
   @Test

--- a/src/test/java/ca/gc/aafc/agent/api/PersonRestJsonIT.java
+++ b/src/test/java/ca/gc/aafc/agent/api/PersonRestJsonIT.java
@@ -98,6 +98,11 @@ public class PersonRestJsonIT extends DBBackedIntegrationTest {
   }
 
   @Test
+  public void patch_InvalidUUID_ReturnsBadRequest() {
+    patchPerson("name", "email", "invalid").then().statusCode(HttpStatus.BAD_REQUEST_400);
+  }
+
+  @Test
   public void get_PersistedPerson_ReturnsOkayAndBody() {
     String displayName = TestableEntityFactory.generateRandomNameLettersOnly(10);
     String email = TestableEntityFactory.generateRandomNameLettersOnly(5);

--- a/src/test/java/ca/gc/aafc/agent/api/PersonRestJsonIT.java
+++ b/src/test/java/ca/gc/aafc/agent/api/PersonRestJsonIT.java
@@ -121,6 +121,12 @@ public class PersonRestJsonIT extends DBBackedIntegrationTest {
   }
 
   @Test
+  public void get_InvalidUUID_ReturnsResourceNotFound() {
+    Response response = sendGet("12131231");
+    response.then().statusCode(HttpStatus.BAD_REQUEST_400);
+  }
+
+  @Test
   public void delete_PeresistedPerson_ReturnsNoConentAndDeletes() {
     String id = persistPerson("person", "person@agen.ca");
 

--- a/src/test/java/ca/gc/aafc/agent/api/PersonRestJsonIT.java
+++ b/src/test/java/ca/gc/aafc/agent/api/PersonRestJsonIT.java
@@ -146,6 +146,11 @@ public class PersonRestJsonIT extends DBBackedIntegrationTest {
     getResponse.then().statusCode(HttpStatus.NOT_FOUND_404);
   }
 
+  @Test
+  public void delete_InvalidUUID_ReturnsBadRequest() {
+    sendDelete("invalid id").then().statusCode(HttpStatus.BAD_REQUEST_400);
+  }
+
   /**
    * Send a HTTP DELETE request to the person endpoint with a given id
    *

--- a/src/test/java/ca/gc/aafc/agent/api/PersonRestJsonIT.java
+++ b/src/test/java/ca/gc/aafc/agent/api/PersonRestJsonIT.java
@@ -121,9 +121,13 @@ public class PersonRestJsonIT extends DBBackedIntegrationTest {
   }
 
   @Test
-  public void get_InvalidUUID_ReturnsResourceNotFound() {
-    Response response = sendGet("12131231");
-    response.then().statusCode(HttpStatus.BAD_REQUEST_400);
+  public void get_InvalidUUID_ReturnsBadRequest() {
+    Response getResponse = sendGet("12131231");
+    getResponse.then().statusCode(HttpStatus.BAD_REQUEST_400);
+
+    Response getWithQueryString = sendGet("12131231"+
+    "?filter[acDerivedFrom.id][EQ]=a8098c1a-f86e-11da-bd1a-00112444be1e");
+    getWithQueryString.then().statusCode(HttpStatus.BAD_REQUEST_400);
   }
 
   @Test


### PR DESCRIPTION
There seems to be no appropriate way to map this type of error with Crnk's usual error mapping for repositories.

The idea here is to use a bean that will over ride the Crnk filter to add layer of id validation, so we can return an appropriate response.

The RequestUuidValidationFilter could live in the dina base api, but would need to be declared in the module using the bean.
```
  @Bean
  public RequestUuidValidationFilter idValidator() {
    return new RequestUuidValidationFilter("/api/v1", Arrays.asList("person"));
  }
````

The RequestUuidValidationFilter supports GET, PATCH, DELETE operations. Upon creation you would give it the web path prefix (/api/v1) and a list of endpoints you would like to validate against.

This allows us to skip endpoints we do not want to validate like get /file/{Name}