### PR TITLE
20384 org name multi language

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <asciidoctor-maven-plugin.version>2.0.0</asciidoctor-maven-plugin.version>
     <asciidoctorj.diagram.version>2.0.2</asciidoctorj.diagram.version>
     <hibernate-types-52.version>2.9.13</hibernate-types-52.version>
-    <dina-base-api.version>0.36</dina-base-api.version>
+    <dina-base-api.version>0.38</dina-base-api.version>
 
     <spring-boot-maven-plugin.fork>false</spring-boot-maven-plugin.fork>
   </properties>

--- a/src/main/java/ca/gc/aafc/agent/api/dto/OrganizationDto.java
+++ b/src/main/java/ca/gc/aafc/agent/api/dto/OrganizationDto.java
@@ -3,6 +3,7 @@ package ca.gc.aafc.agent.api.dto;
 import ca.gc.aafc.agent.api.entities.Organization;
 import ca.gc.aafc.agent.api.entities.OrganizationNameTranslation;
 import ca.gc.aafc.dina.dto.RelatedEntity;
+import ca.gc.aafc.dina.mapper.CustomFieldResolver;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.crnk.core.resource.annotations.JsonApiId;
@@ -12,6 +13,7 @@ import lombok.Data;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @RelatedEntity(Organization.class)
 @SuppressFBWarnings({"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
@@ -29,6 +31,25 @@ public class OrganizationDto {
   private OffsetDateTime createdOn;
 
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
-  private List<OrganizationNameTranslation> nameTranslations;
+  private List<OrganizationNameTranslationDto> nameTranslations;
 
+  @CustomFieldResolver(fieldName = "nameTranslations")
+  public static List<OrganizationNameTranslationDto> nameTranslationsToDTO(Organization entity) {
+    return entity.getNameTranslations() == null ? null : entity.getNameTranslations()
+      .stream()
+      .map(translation -> OrganizationNameTranslationDto.builder()
+        .languageCode(translation.getLanguageCode())
+        .value(translation.getValue()).build())
+      .collect(Collectors.toList());
+  }
+
+  @CustomFieldResolver(fieldName = "nameTranslations")
+  public static List<OrganizationNameTranslation> nameTranslationsToEntity(OrganizationDto dto) {
+    return dto.getNameTranslations() == null ? null : dto.getNameTranslations()
+      .stream()
+      .map(translation -> OrganizationNameTranslation.builder()
+        .languageCode(translation.getLanguageCode())
+        .value(translation.getValue()).build())
+      .collect(Collectors.toList());
+  }
 }

--- a/src/main/java/ca/gc/aafc/agent/api/dto/OrganizationDto.java
+++ b/src/main/java/ca/gc/aafc/agent/api/dto/OrganizationDto.java
@@ -32,12 +32,12 @@ public class OrganizationDto {
   private List<OrganizationNameTranslation> nameTranslations;
 
   @CustomFieldResolver(fieldName = "nameTranslations")
-  private static List<OrganizationNameTranslation> toDTO(Organization entity) {
+  public static List<OrganizationNameTranslation> toDTO(Organization entity) {
     return Collections.emptyList();
   }
 
   @CustomFieldResolver(fieldName = "nameTranslations")
-  private static List<OrganizationNameTranslation> toEntity(OrganizationDto dto) {
+  public static List<OrganizationNameTranslation> toEntity(OrganizationDto dto) {
     return Collections.emptyList();
   }
 

--- a/src/main/java/ca/gc/aafc/agent/api/dto/OrganizationDto.java
+++ b/src/main/java/ca/gc/aafc/agent/api/dto/OrganizationDto.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.crnk.core.resource.annotations.JsonApiId;
 import io.crnk.core.resource.annotations.JsonApiResource;
-import io.crnk.core.resource.annotations.JsonIncludeStrategy;
 import lombok.Data;
 
 import java.time.OffsetDateTime;

--- a/src/main/java/ca/gc/aafc/agent/api/dto/OrganizationDto.java
+++ b/src/main/java/ca/gc/aafc/agent/api/dto/OrganizationDto.java
@@ -31,14 +31,4 @@ public class OrganizationDto {
 
   private List<OrganizationNameTranslation> nameTranslations;
 
-  @CustomFieldResolver(fieldName = "nameTranslations")
-  public static List<OrganizationNameTranslation> toDTO(Organization entity) {
-    return Collections.emptyList();
-  }
-
-  @CustomFieldResolver(fieldName = "nameTranslations")
-  public static List<OrganizationNameTranslation> toEntity(OrganizationDto dto) {
-    return Collections.emptyList();
-  }
-
 }

--- a/src/main/java/ca/gc/aafc/agent/api/dto/OrganizationDto.java
+++ b/src/main/java/ca/gc/aafc/agent/api/dto/OrganizationDto.java
@@ -24,7 +24,6 @@ public class OrganizationDto {
   @JsonApiId
   private UUID uuid;
 
-  private String name;
   private String[] aliases;
 
   private String createdBy;

--- a/src/main/java/ca/gc/aafc/agent/api/dto/OrganizationDto.java
+++ b/src/main/java/ca/gc/aafc/agent/api/dto/OrganizationDto.java
@@ -1,17 +1,21 @@
 package ca.gc.aafc.agent.api.dto;
 
-import java.time.OffsetDateTime;
-import java.util.UUID;
-
 import ca.gc.aafc.agent.api.entities.Organization;
+import ca.gc.aafc.agent.api.entities.OrganizationNameTranslation;
 import ca.gc.aafc.dina.dto.RelatedEntity;
+import ca.gc.aafc.dina.mapper.CustomFieldResolver;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.crnk.core.resource.annotations.JsonApiId;
 import io.crnk.core.resource.annotations.JsonApiResource;
 import lombok.Data;
 
+import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
 @RelatedEntity(Organization.class)
-@SuppressFBWarnings({ "EI_EXPOSE_REP", "EI_EXPOSE_REP2" })
+@SuppressFBWarnings({"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
 @Data
 @JsonApiResource(type = "organization")
 public class OrganizationDto {
@@ -24,5 +28,17 @@ public class OrganizationDto {
 
   private String createdBy;
   private OffsetDateTime createdOn;
-  
+
+  private List<OrganizationNameTranslation> nameTranslations;
+
+  @CustomFieldResolver(fieldName = "nameTranslations")
+  private static List<OrganizationNameTranslation> toDTO(Organization entity) {
+    return Collections.emptyList();
+  }
+
+  @CustomFieldResolver(fieldName = "nameTranslations")
+  private static List<OrganizationNameTranslation> toEntity(OrganizationDto dto) {
+    return Collections.emptyList();
+  }
+
 }

--- a/src/main/java/ca/gc/aafc/agent/api/dto/OrganizationDto.java
+++ b/src/main/java/ca/gc/aafc/agent/api/dto/OrganizationDto.java
@@ -3,14 +3,12 @@ package ca.gc.aafc.agent.api.dto;
 import ca.gc.aafc.agent.api.entities.Organization;
 import ca.gc.aafc.agent.api.entities.OrganizationNameTranslation;
 import ca.gc.aafc.dina.dto.RelatedEntity;
-import ca.gc.aafc.dina.mapper.CustomFieldResolver;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.crnk.core.resource.annotations.JsonApiId;
 import io.crnk.core.resource.annotations.JsonApiResource;
 import lombok.Data;
 
 import java.time.OffsetDateTime;
-import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 

--- a/src/main/java/ca/gc/aafc/agent/api/dto/OrganizationDto.java
+++ b/src/main/java/ca/gc/aafc/agent/api/dto/OrganizationDto.java
@@ -30,11 +30,11 @@ public class OrganizationDto {
   private OffsetDateTime createdOn;
 
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
-  private List<OrganizationNameTranslationDto> nameTranslations;
+  private List<OrganizationNameTranslationDto> names;
 
-  @CustomFieldResolver(fieldName = "nameTranslations")
+  @CustomFieldResolver(fieldName = "names")
   public static List<OrganizationNameTranslationDto> nameTranslationsToDTO(Organization entity) {
-    return entity.getNameTranslations() == null ? null : entity.getNameTranslations()
+    return entity.getNames() == null ? null : entity.getNames()
       .stream()
       .map(translation -> OrganizationNameTranslationDto.builder()
         .languageCode(translation.getLanguageCode())
@@ -42,9 +42,9 @@ public class OrganizationDto {
       .collect(Collectors.toList());
   }
 
-  @CustomFieldResolver(fieldName = "nameTranslations")
+  @CustomFieldResolver(fieldName = "names")
   public static List<OrganizationNameTranslation> nameTranslationsToEntity(OrganizationDto dto) {
-    return dto.getNameTranslations() == null ? null : dto.getNameTranslations()
+    return dto.getNames() == null ? null : dto.getNames()
       .stream()
       .map(translation -> OrganizationNameTranslation.builder()
         .languageCode(translation.getLanguageCode())

--- a/src/main/java/ca/gc/aafc/agent/api/dto/OrganizationDto.java
+++ b/src/main/java/ca/gc/aafc/agent/api/dto/OrganizationDto.java
@@ -3,9 +3,11 @@ package ca.gc.aafc.agent.api.dto;
 import ca.gc.aafc.agent.api.entities.Organization;
 import ca.gc.aafc.agent.api.entities.OrganizationNameTranslation;
 import ca.gc.aafc.dina.dto.RelatedEntity;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.crnk.core.resource.annotations.JsonApiId;
 import io.crnk.core.resource.annotations.JsonApiResource;
+import io.crnk.core.resource.annotations.JsonIncludeStrategy;
 import lombok.Data;
 
 import java.time.OffsetDateTime;
@@ -27,6 +29,7 @@ public class OrganizationDto {
   private String createdBy;
   private OffsetDateTime createdOn;
 
+  @JsonInclude(JsonInclude.Include.NON_EMPTY)
   private List<OrganizationNameTranslation> nameTranslations;
 
 }

--- a/src/main/java/ca/gc/aafc/agent/api/dto/OrganizationDto.java
+++ b/src/main/java/ca/gc/aafc/agent/api/dto/OrganizationDto.java
@@ -38,7 +38,7 @@ public class OrganizationDto {
       .stream()
       .map(translation -> OrganizationNameTranslationDto.builder()
         .languageCode(translation.getLanguageCode())
-        .value(translation.getValue()).build())
+        .name(translation.getName()).build())
       .collect(Collectors.toList());
   }
 
@@ -48,7 +48,7 @@ public class OrganizationDto {
       .stream()
       .map(translation -> OrganizationNameTranslation.builder()
         .languageCode(translation.getLanguageCode())
-        .value(translation.getValue()).build())
+        .name(translation.getName()).build())
       .collect(Collectors.toList());
   }
 }

--- a/src/main/java/ca/gc/aafc/agent/api/dto/OrganizationNameTranslationDto.java
+++ b/src/main/java/ca/gc/aafc/agent/api/dto/OrganizationNameTranslationDto.java
@@ -1,0 +1,11 @@
+package ca.gc.aafc.agent.api.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class OrganizationNameTranslationDto {
+  private String languageCode;
+  private String value;
+}

--- a/src/main/java/ca/gc/aafc/agent/api/dto/OrganizationNameTranslationDto.java
+++ b/src/main/java/ca/gc/aafc/agent/api/dto/OrganizationNameTranslationDto.java
@@ -7,5 +7,5 @@ import lombok.Data;
 @Builder
 public class OrganizationNameTranslationDto {
   private String languageCode;
-  private String value;
+  private String name;
 }

--- a/src/main/java/ca/gc/aafc/agent/api/entities/Organization.java
+++ b/src/main/java/ca/gc/aafc/agent/api/entities/Organization.java
@@ -24,7 +24,6 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.ManyToMany;
 import javax.persistence.OneToMany;
-import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import java.time.OffsetDateTime;
 import java.util.List;

--- a/src/main/java/ca/gc/aafc/agent/api/entities/Organization.java
+++ b/src/main/java/ca/gc/aafc/agent/api/entities/Organization.java
@@ -71,7 +71,7 @@ public class Organization implements DinaEntity {
 
   @OneToMany(
     mappedBy = "organization",
-    cascade = {CascadeType.PERSIST, CascadeType.REMOVE},
+    cascade = {CascadeType.PERSIST,CascadeType.MERGE, CascadeType.REMOVE},
     fetch = FetchType.EAGER)
   private List<OrganizationNameTranslation> nameTranslations;
 }

--- a/src/main/java/ca/gc/aafc/agent/api/entities/Organization.java
+++ b/src/main/java/ca/gc/aafc/agent/api/entities/Organization.java
@@ -54,9 +54,6 @@ public class Organization implements DinaEntity {
   @Column(name = "uuid", unique = true)
   private UUID uuid;
 
-  @NotBlank
-  private String name;
-
   @Type(type = "string-array")
   private String[] aliases;
 

--- a/src/main/java/ca/gc/aafc/agent/api/entities/Organization.java
+++ b/src/main/java/ca/gc/aafc/agent/api/entities/Organization.java
@@ -71,7 +71,7 @@ public class Organization implements DinaEntity {
 
   @OneToMany(
     mappedBy = "organization",
-    cascade = {CascadeType.PERSIST,CascadeType.MERGE, CascadeType.REMOVE},
+    cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE},
     fetch = FetchType.EAGER)
   private List<OrganizationNameTranslation> nameTranslations;
 }

--- a/src/main/java/ca/gc/aafc/agent/api/entities/Organization.java
+++ b/src/main/java/ca/gc/aafc/agent/api/entities/Organization.java
@@ -69,6 +69,9 @@ public class Organization implements DinaEntity {
   @ManyToMany(mappedBy = "organizations", fetch = FetchType.LAZY)
   private List<Person> persons;
 
-  @OneToMany(mappedBy = "organization", cascade = CascadeType.PERSIST, fetch = FetchType.EAGER)
+  @OneToMany(
+    mappedBy = "organization",
+    cascade = {CascadeType.PERSIST, CascadeType.REMOVE},
+    fetch = FetchType.EAGER)
   private List<OrganizationNameTranslation> nameTranslations;
 }

--- a/src/main/java/ca/gc/aafc/agent/api/entities/Organization.java
+++ b/src/main/java/ca/gc/aafc/agent/api/entities/Organization.java
@@ -69,6 +69,6 @@ public class Organization implements DinaEntity {
   @ManyToMany(mappedBy = "organizations", fetch = FetchType.LAZY)
   private List<Person> persons;
 
-  @OneToMany(mappedBy = "organization", fetch = FetchType.EAGER)
+  @OneToMany(mappedBy = "organization", cascade = CascadeType.PERSIST, fetch = FetchType.EAGER)
   private List<OrganizationNameTranslation> nameTranslations;
 }

--- a/src/main/java/ca/gc/aafc/agent/api/entities/Organization.java
+++ b/src/main/java/ca/gc/aafc/agent/api/entities/Organization.java
@@ -1,27 +1,7 @@
 package ca.gc.aafc.agent.api.entities;
 
-import java.time.OffsetDateTime;
-import java.util.List;
-import java.util.UUID;
-
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.ManyToMany;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-
-import com.vladmihalcea.hibernate.type.array.StringArrayType;
-
-import org.hibernate.annotations.NaturalId;
-import org.hibernate.annotations.NaturalIdCache;
-import org.hibernate.annotations.Type;
-import org.hibernate.annotations.TypeDef;
-
 import ca.gc.aafc.dina.entity.DinaEntity;
+import com.vladmihalcea.hibernate.type.array.StringArrayType;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -30,6 +10,25 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import org.hibernate.annotations.NaturalId;
+import org.hibernate.annotations.NaturalIdCache;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToMany;
+import javax.persistence.OneToMany;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
 
 @Entity
 @TypeDef(name = "string-array", typeClass = StringArrayType.class)
@@ -40,7 +39,9 @@ import lombok.ToString;
 @ToString
 @EqualsAndHashCode
 @Builder
-@SuppressFBWarnings(justification = "ok for Hibernate Entity", value = { "EI_EXPOSE_REP", "EI_EXPOSE_REP2" })
+@SuppressFBWarnings(
+  justification = "ok for Hibernate Entity",
+  value = {"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
 @NaturalIdCache
 public class Organization implements DinaEntity {
 
@@ -66,5 +67,8 @@ public class Organization implements DinaEntity {
   private OffsetDateTime createdOn;
 
   @ManyToMany(mappedBy = "organizations", fetch = FetchType.LAZY)
-  private List<Person> persons;  
+  private List<Person> persons;
+
+  @OneToMany(mappedBy = "organization", fetch = FetchType.EAGER)
+  private List<OrganizationNameTranslation> nameTranslations;
 }

--- a/src/main/java/ca/gc/aafc/agent/api/entities/Organization.java
+++ b/src/main/java/ca/gc/aafc/agent/api/entities/Organization.java
@@ -70,5 +70,5 @@ public class Organization implements DinaEntity {
     mappedBy = "organization",
     cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE},
     fetch = FetchType.EAGER)
-  private List<OrganizationNameTranslation> nameTranslations;
+  private List<OrganizationNameTranslation> names;
 }

--- a/src/main/java/ca/gc/aafc/agent/api/entities/OrganizationNameTranslation.java
+++ b/src/main/java/ca/gc/aafc/agent/api/entities/OrganizationNameTranslation.java
@@ -1,0 +1,48 @@
+package ca.gc.aafc.agent.api.entities;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+@Entity(name = "org_name_translation")
+@Getter
+@Setter
+@AllArgsConstructor
+@RequiredArgsConstructor
+@ToString
+@EqualsAndHashCode
+@Builder
+@SuppressFBWarnings(
+  justification = "ok for Hibernate Entity",
+  value = {"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
+public class OrganizationNameTranslation {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Integer id;
+
+  @NotBlank
+  private String language;
+
+  @NotBlank
+  private String value;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @NotNull
+  private Organization organization;
+
+}

--- a/src/main/java/ca/gc/aafc/agent/api/entities/OrganizationNameTranslation.java
+++ b/src/main/java/ca/gc/aafc/agent/api/entities/OrganizationNameTranslation.java
@@ -39,7 +39,7 @@ public class OrganizationNameTranslation {
   private Integer id;
 
   @NotBlank
-  private String language;
+  private String languageCode;
 
   @NotBlank
   private String value;

--- a/src/main/java/ca/gc/aafc/agent/api/entities/OrganizationNameTranslation.java
+++ b/src/main/java/ca/gc/aafc/agent/api/entities/OrganizationNameTranslation.java
@@ -47,6 +47,7 @@ public class OrganizationNameTranslation {
   @ManyToOne(fetch = FetchType.LAZY)
   @NotNull
   @JsonBackReference
+  @EqualsAndHashCode.Exclude
   private Organization organization;
 
 }

--- a/src/main/java/ca/gc/aafc/agent/api/entities/OrganizationNameTranslation.java
+++ b/src/main/java/ca/gc/aafc/agent/api/entities/OrganizationNameTranslation.java
@@ -37,7 +37,7 @@ public class OrganizationNameTranslation {
   private Integer id;
 
   @NotBlank
-  @Size(min = 2)
+  @Size(max = 2)
   private String languageCode;
 
   @NotBlank

--- a/src/main/java/ca/gc/aafc/agent/api/entities/OrganizationNameTranslation.java
+++ b/src/main/java/ca/gc/aafc/agent/api/entities/OrganizationNameTranslation.java
@@ -41,7 +41,7 @@ public class OrganizationNameTranslation {
   private String languageCode;
 
   @NotBlank
-  private String value;
+  private String name;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @NotNull

--- a/src/main/java/ca/gc/aafc/agent/api/entities/OrganizationNameTranslation.java
+++ b/src/main/java/ca/gc/aafc/agent/api/entities/OrganizationNameTranslation.java
@@ -1,7 +1,5 @@
 package ca.gc.aafc.agent.api.entities;
 
-import com.fasterxml.jackson.annotation.JsonBackReference;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -35,7 +33,6 @@ public class OrganizationNameTranslation {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @JsonIgnore
   private Integer id;
 
   @NotBlank
@@ -46,7 +43,6 @@ public class OrganizationNameTranslation {
 
   @ManyToOne(fetch = FetchType.LAZY)
   @NotNull
-  @JsonBackReference
   @EqualsAndHashCode.Exclude
   private Organization organization;
 

--- a/src/main/java/ca/gc/aafc/agent/api/entities/OrganizationNameTranslation.java
+++ b/src/main/java/ca/gc/aafc/agent/api/entities/OrganizationNameTranslation.java
@@ -17,6 +17,7 @@ import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 
 @Entity(name = "org_name_translation")
 @Getter
@@ -36,6 +37,7 @@ public class OrganizationNameTranslation {
   private Integer id;
 
   @NotBlank
+  @Size(min = 2)
   private String languageCode;
 
   @NotBlank

--- a/src/main/java/ca/gc/aafc/agent/api/entities/OrganizationNameTranslation.java
+++ b/src/main/java/ca/gc/aafc/agent/api/entities/OrganizationNameTranslation.java
@@ -37,7 +37,7 @@ public class OrganizationNameTranslation {
   private Integer id;
 
   @NotBlank
-  @Size(max = 2)
+  @Size(max = 2, min = 2)
   private String languageCode;
 
   @NotBlank

--- a/src/main/java/ca/gc/aafc/agent/api/entities/OrganizationNameTranslation.java
+++ b/src/main/java/ca/gc/aafc/agent/api/entities/OrganizationNameTranslation.java
@@ -1,5 +1,7 @@
 package ca.gc.aafc.agent.api.entities;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -33,6 +35,7 @@ public class OrganizationNameTranslation {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @JsonIgnore
   private Integer id;
 
   @NotBlank
@@ -43,6 +46,7 @@ public class OrganizationNameTranslation {
 
   @ManyToOne(fetch = FetchType.LAZY)
   @NotNull
+  @JsonBackReference
   private Organization organization;
 
 }

--- a/src/main/java/ca/gc/aafc/agent/api/repository/OrganizationRepository.java
+++ b/src/main/java/ca/gc/aafc/agent/api/repository/OrganizationRepository.java
@@ -32,7 +32,8 @@ public class OrganizationRepository extends DinaRepository<OrganizationDto, Orga
       new DinaMapper<>(OrganizationDto.class),
       OrganizationDto.class,
       Organization.class,
-      filterResolver);
+      filterResolver,
+      null);
     this.authenticatedUser = authenticatedUser;
   }
 

--- a/src/main/java/ca/gc/aafc/agent/api/repository/OrganizationRepository.java
+++ b/src/main/java/ca/gc/aafc/agent/api/repository/OrganizationRepository.java
@@ -1,9 +1,5 @@
 package ca.gc.aafc.agent.api.repository;
 
-import java.util.Optional;
-
-import org.springframework.stereotype.Repository;
-
 import ca.gc.aafc.agent.api.dto.OrganizationDto;
 import ca.gc.aafc.agent.api.entities.Organization;
 import ca.gc.aafc.agent.api.service.OrganizationAuthorizationService;
@@ -12,18 +8,27 @@ import ca.gc.aafc.dina.mapper.DinaMapper;
 import ca.gc.aafc.dina.repository.DinaRepository;
 import ca.gc.aafc.dina.security.DinaAuthenticatedUser;
 import ca.gc.aafc.dina.service.DinaService;
+import io.crnk.core.exception.BadRequestException;
 import lombok.NonNull;
+import org.apache.commons.collections.CollectionUtils;
+import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public class OrganizationRepository extends DinaRepository<OrganizationDto, Organization> {
 
   private Optional<DinaAuthenticatedUser> authenticatedUser;
-  
+  private final MessageSource messageSource;
+
   public OrganizationRepository(
     @NonNull DinaService<Organization> dinaService,
     @NonNull OrganizationAuthorizationService authorizationService,
     @NonNull DinaFilterResolver filterResolver,
-    Optional<DinaAuthenticatedUser> authenticatedUser
+    Optional<DinaAuthenticatedUser> authenticatedUser,
+    MessageSource messageSource
   ) {
     super(
       dinaService,
@@ -35,14 +40,27 @@ public class OrganizationRepository extends DinaRepository<OrganizationDto, Orga
       filterResolver,
       null);
     this.authenticatedUser = authenticatedUser;
+    this.messageSource = messageSource;
   }
 
   @Override
   public <S extends OrganizationDto> S create(S resource) {
+    if (CollectionUtils.isEmpty(resource.getNames())) {
+      throw new BadRequestException(messageSource.getMessage(
+        "organization.constraint.required.name", null, LocaleContextHolder.getLocale()));
+    }
     if (authenticatedUser.isPresent()) {
       resource.setCreatedBy(authenticatedUser.get().getUsername());
     }
     return super.create(resource);
   }
 
+  @Override
+  public <S extends OrganizationDto> S save(S resource) {
+    if (CollectionUtils.isEmpty(resource.getNames())) {
+      throw new BadRequestException(messageSource.getMessage(
+        "organization.constraint.required.name", null, LocaleContextHolder.getLocale()));
+    }
+    return super.save(resource);
+  }
 }

--- a/src/main/java/ca/gc/aafc/agent/api/repository/PersonRepository.java
+++ b/src/main/java/ca/gc/aafc/agent/api/repository/PersonRepository.java
@@ -33,7 +33,8 @@ public class PersonRepository extends DinaRepository<PersonDto, Person> {
       new DinaMapper<>(PersonDto.class),
       PersonDto.class,
       Person.class,
-      filterResolver);
+      filterResolver,
+      null);
     this.authenticatedUser = authenticatedUser;
   }
 

--- a/src/main/java/ca/gc/aafc/agent/api/service/OrganizationService.java
+++ b/src/main/java/ca/gc/aafc/agent/api/service/OrganizationService.java
@@ -1,13 +1,20 @@
 package ca.gc.aafc.agent.api.service;
 
 import ca.gc.aafc.agent.api.entities.Organization;
+import ca.gc.aafc.agent.api.entities.OrganizationNameTranslation;
 import ca.gc.aafc.dina.jpa.BaseDAO;
 import ca.gc.aafc.dina.service.DinaService;
 import lombok.NonNull;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 
+import javax.persistence.criteria.Predicate;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 public class OrganizationService extends DinaService<Organization> {
@@ -33,7 +40,31 @@ public class OrganizationService extends DinaService<Organization> {
 
   @Override
   protected void preUpdate(Organization entity) {
+    List<OrganizationNameTranslation> translations = entity.getNameTranslations();
+    if (CollectionUtils.isNotEmpty(translations)) {
+      entity.setNameTranslations(null);
+      Map<String, OrganizationNameTranslation> persistedTranslations = this.findAll(
+        OrganizationNameTranslation.class,
+        (cb, root) -> new Predicate[]{cb.equal(root.get("organization"), entity)},
+        null, 0, 1000).stream().collect(
+        Collectors.toMap(OrganizationNameTranslation::getLanguage, Function.identity()));
 
+      List<OrganizationNameTranslation> toPersist = translations.stream().map(nameTranslation -> {
+        String language = nameTranslation.getLanguage();
+        if (persistedTranslations.containsKey(language)) {
+          OrganizationNameTranslation persisted = persistedTranslations.get(language);
+          if (!StringUtils.equalsIgnoreCase(persisted.getValue(), nameTranslation.getValue())) {
+            persisted.setValue(nameTranslation.getValue());
+          }
+          return persisted;
+        } else {
+          nameTranslation.setOrganization(entity);
+          return nameTranslation;
+        }
+      }).collect(Collectors.toList());
+
+      entity.setNameTranslations(toPersist);
+    }
   }
 
 }

--- a/src/main/java/ca/gc/aafc/agent/api/service/OrganizationService.java
+++ b/src/main/java/ca/gc/aafc/agent/api/service/OrganizationService.java
@@ -32,8 +32,8 @@ public class OrganizationService extends DinaService<Organization> {
     //Give new Organization UUID
     entity.setUuid(UUID.randomUUID());
     //Link name translations to the Organization before cascade
-    if (CollectionUtils.isNotEmpty(entity.getNameTranslations())) {
-      entity.getNameTranslations().forEach(trans -> trans.setOrganization(entity));
+    if (CollectionUtils.isNotEmpty(entity.getNames())) {
+      entity.getNames().forEach(trans -> trans.setOrganization(entity));
     }
   }
 
@@ -44,15 +44,15 @@ public class OrganizationService extends DinaService<Organization> {
 
   @Override
   protected void preUpdate(Organization entity) {
-    List<OrganizationNameTranslation> incomingTranslations = entity.getNameTranslations();
-    entity.setNameTranslations(null);
+    List<OrganizationNameTranslation> incomingTranslations = entity.getNames();
+    entity.setNames(null);
     Map<String, OrganizationNameTranslation> oldTranslations = fetchTranslations(entity);
 
     if (CollectionUtils.isNotEmpty(incomingTranslations)) {
       Map<String, OrganizationNameTranslation> newTranslations =
         mapTranslationsToPersist(entity, incomingTranslations, oldTranslations);
       removeUnusedTranslations(oldTranslations, newTranslations);
-      entity.setNameTranslations(new ArrayList<>(newTranslations.values()));
+      entity.setNames(new ArrayList<>(newTranslations.values()));
     } else {
       oldTranslations.values().forEach(dao::delete);
     }

--- a/src/main/java/ca/gc/aafc/agent/api/service/OrganizationService.java
+++ b/src/main/java/ca/gc/aafc/agent/api/service/OrganizationService.java
@@ -1,13 +1,13 @@
 package ca.gc.aafc.agent.api.service;
 
-import java.util.UUID;
-
-import org.springframework.stereotype.Service;
-
 import ca.gc.aafc.agent.api.entities.Organization;
 import ca.gc.aafc.dina.jpa.BaseDAO;
 import ca.gc.aafc.dina.service.DinaService;
 import lombok.NonNull;
+import org.apache.commons.collections.CollectionUtils;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
 
 @Service
 public class OrganizationService extends DinaService<Organization> {
@@ -18,7 +18,12 @@ public class OrganizationService extends DinaService<Organization> {
 
   @Override
   protected void preCreate(Organization entity) {
+    //Give new Organization UUID
     entity.setUuid(UUID.randomUUID());
+    //Link name translations to the Organization before cascade
+    if (CollectionUtils.isNotEmpty(entity.getNameTranslations())) {
+      entity.getNameTranslations().forEach(trans -> trans.setOrganization(entity));
+    }
   }
 
   @Override

--- a/src/main/java/ca/gc/aafc/agent/api/service/OrganizationService.java
+++ b/src/main/java/ca/gc/aafc/agent/api/service/OrganizationService.java
@@ -44,16 +44,14 @@ public class OrganizationService extends DinaService<Organization> {
 
   @Override
   protected void preUpdate(Organization entity) {
-    List<OrganizationNameTranslation> translations = entity.getNameTranslations();
+    List<OrganizationNameTranslation> incomingTranslations = entity.getNameTranslations();
     entity.setNameTranslations(null);
     Map<String, OrganizationNameTranslation> oldTranslations = fetchTranslations(entity);
 
-    if (CollectionUtils.isNotEmpty(translations)) {
+    if (CollectionUtils.isNotEmpty(incomingTranslations)) {
       Map<String, OrganizationNameTranslation> newTranslations =
-        mapTranslationsToPersist(entity, translations, oldTranslations);
-
+        mapTranslationsToPersist(entity, incomingTranslations, oldTranslations);
       removeUnusedTranslations(oldTranslations, newTranslations);
-
       entity.setNameTranslations(new ArrayList<>(newTranslations.values()));
     } else {
       oldTranslations.values().forEach(dao::delete);
@@ -63,7 +61,7 @@ public class OrganizationService extends DinaService<Organization> {
   /**
    * Returns translations for a given entity.
    *
-   * @param entity a given entity.
+   * @param entity - a given entity.
    * @return Returns translations for a given entity.
    */
   private Map<String, OrganizationNameTranslation> fetchTranslations(@NonNull Organization entity) {
@@ -76,7 +74,7 @@ public class OrganizationService extends DinaService<Organization> {
 
   /**
    * Returns a Map of translations per language. the returned translations are backed by the
-   * database if they already exist.
+   * database if they already exist, or they are linked to the given entity.
    *
    * @param entity       - owner of the translations
    * @param translations - translations to map

--- a/src/main/java/ca/gc/aafc/agent/api/service/OrganizationService.java
+++ b/src/main/java/ca/gc/aafc/agent/api/service/OrganizationService.java
@@ -126,8 +126,8 @@ public class OrganizationService extends DinaService<Organization> {
     String language = translation.getLanguageCode();
     if (persistedMap.containsKey(language)) {
       OrganizationNameTranslation persisted = persistedMap.get(language);
-      if (!StringUtils.equalsIgnoreCase(persisted.getValue(), translation.getValue())) {
-        persisted.setValue(translation.getValue());
+      if (!StringUtils.equalsIgnoreCase(persisted.getName(), translation.getName())) {
+        persisted.setName(translation.getName());
       }
       return persisted;
     } else {

--- a/src/main/java/ca/gc/aafc/agent/api/service/OrganizationService.java
+++ b/src/main/java/ca/gc/aafc/agent/api/service/OrganizationService.java
@@ -69,7 +69,7 @@ public class OrganizationService extends DinaService<Organization> {
       OrganizationNameTranslation.class,
       (cb, root) -> new Predicate[]{cb.equal(root.get("organization"), entity)},
       null, 0, Integer.MAX_VALUE).stream().collect(
-      Collectors.toMap(OrganizationNameTranslation::getLanguage, Function.identity()));
+      Collectors.toMap(OrganizationNameTranslation::getLanguageCode, Function.identity()));
   }
 
   /**
@@ -88,7 +88,7 @@ public class OrganizationService extends DinaService<Organization> {
   ) {
     return translations.stream()
       .map(nameTranslation -> linkTranslation(entity, persistedMap, nameTranslation))
-      .collect(Collectors.toMap(OrganizationNameTranslation::getLanguage, Function.identity()));
+      .collect(Collectors.toMap(OrganizationNameTranslation::getLanguageCode, Function.identity()));
   }
 
   /**
@@ -102,7 +102,7 @@ public class OrganizationService extends DinaService<Organization> {
     @NonNull Map<String, OrganizationNameTranslation> currentTranslations
   ) {
     oldTranslations.values().forEach(translation -> {
-      if (!currentTranslations.containsKey(translation.getLanguage())) {
+      if (!currentTranslations.containsKey(translation.getLanguageCode())) {
         dao.delete(translation);
       }
     });
@@ -123,7 +123,7 @@ public class OrganizationService extends DinaService<Organization> {
     @NonNull Map<String, OrganizationNameTranslation> persistedMap,
     @NonNull OrganizationNameTranslation translation
   ) {
-    String language = translation.getLanguage();
+    String language = translation.getLanguageCode();
     if (persistedMap.containsKey(language)) {
       OrganizationNameTranslation persisted = persistedMap.get(language);
       if (!StringUtils.equalsIgnoreCase(persisted.getValue(), translation.getValue())) {

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -4,5 +4,6 @@
   <include file="db/changelog/migrations/1-Add_CreatedBy_and_CreatedOn_agent_table.xml" />
   <include file="db/changelog/migrations/2-Rename_agent_tableName_to_person_and_update_primaryKey_and_unique_index_names.xml" />  
   <include file="db/changelog/migrations/3-Add_Organization_table.xml" />
-  <include file="db/changelog/migrations/4-Add_person_to_organization_relationship_table.xml" />  
+  <include file="db/changelog/migrations/4-Add_person_to_organization_relationship_table.xml" />
+  <include file="db/changelog/migrations/5-Add_Org_Name_Translation_Table.xml" />
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/migrations/5-Add_Org_Name_Translation_Table.xml
+++ b/src/main/resources/db/changelog/migrations/5-Add_Org_Name_Translation_Table.xml
@@ -10,9 +10,6 @@
             <column autoIncrement="true" name="id" type="SERIAL">
                 <constraints primaryKey="true" primaryKeyName="pk_name_translation_id"/>
             </column>
-            <column name="uuid" type="uuid">
-                <constraints nullable="false" unique="true" />
-            </column>
             <column name="language" type="VARCHAR(250)">
                 <constraints nullable="false"/>
             </column>
@@ -23,6 +20,12 @@
                 <constraints foreignKeyName="fk_name_translation_organization_id" references="organization(id)"/>
             </column>
         </createTable>
+
+        <addUniqueConstraint
+                columnNames="language, organization_id"
+                constraintName="unique_org_name_translation_language_organization_id"
+                tableName="org_name_translation"
+        />
     </changeSet>
 
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/migrations/5-Add_Org_Name_Translation_Table.xml
+++ b/src/main/resources/db/changelog/migrations/5-Add_Org_Name_Translation_Table.xml
@@ -10,7 +10,7 @@
             <column autoIncrement="true" name="id" type="SERIAL">
                 <constraints primaryKey="true" primaryKeyName="pk_name_translation_id"/>
             </column>
-            <column name="language" type="VARCHAR(250)">
+            <column name="language" type="CHAR(2)">
                 <constraints nullable="false"/>
             </column>
             <column name="value" type="VARCHAR(250)">

--- a/src/main/resources/db/changelog/migrations/5-Add_Org_Name_Translation_Table.xml
+++ b/src/main/resources/db/changelog/migrations/5-Add_Org_Name_Translation_Table.xml
@@ -1,0 +1,28 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no" ?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd"
+        context="schema-change">
+
+    <changeSet context="schema-change" id="5-Add_Org_Name_Translation_Table" author="Jonathan Keyuk">
+        <createTable tableName="org_name_translation">
+            <column autoIncrement="true" name="id" type="SERIAL">
+                <constraints primaryKey="true" primaryKeyName="pk_name_translation_id"/>
+            </column>
+            <column name="uuid" type="uuid">
+                <constraints nullable="false" unique="true" />
+            </column>
+            <column name="language" type="VARCHAR(250)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="value" type="VARCHAR(250)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="organization_id" type="integer">
+                <constraints foreignKeyName="fk_name_translation_organization_id" references="organization(id)"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/migrations/5-Add_Org_Name_Translation_Table.xml
+++ b/src/main/resources/db/changelog/migrations/5-Add_Org_Name_Translation_Table.xml
@@ -10,7 +10,7 @@
             <column autoIncrement="true" name="id" type="SERIAL">
                 <constraints primaryKey="true" primaryKeyName="pk_name_translation_id"/>
             </column>
-            <column name="language" type="CHAR(2)">
+            <column name="language_code" type="CHAR(2)">
                 <constraints nullable="false"/>
             </column>
             <column name="value" type="VARCHAR(250)">
@@ -24,7 +24,7 @@
         <!-- An organization can only have one translation per language    -->
         <sql>
             CREATE UNIQUE INDEX org_name_translation_unique_translation
-            ON org_name_translation (lower(language), organization_id);
+            ON org_name_translation (lower(language_code), organization_id);
         </sql>
     </changeSet>
 

--- a/src/main/resources/db/changelog/migrations/5-Add_Org_Name_Translation_Table.xml
+++ b/src/main/resources/db/changelog/migrations/5-Add_Org_Name_Translation_Table.xml
@@ -21,11 +21,11 @@
             </column>
         </createTable>
 
-        <addUniqueConstraint
-                columnNames="language, organization_id"
-                constraintName="unique_org_name_translation_language_organization_id"
-                tableName="org_name_translation"
-        />
+        <!-- An organization can only have one translation per language    -->
+        <sql>
+            CREATE UNIQUE INDEX org_name_translation_unique_translation
+            ON org_name_translation (lower(language), organization_id);
+        </sql>
     </changeSet>
 
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/migrations/5-Add_Org_Name_Translation_Table.xml
+++ b/src/main/resources/db/changelog/migrations/5-Add_Org_Name_Translation_Table.xml
@@ -26,6 +26,9 @@
             CREATE UNIQUE INDEX org_name_translation_unique_translation
             ON org_name_translation (lower(language_code), organization_id);
         </sql>
+
+        <!--  Drop name column from organization table -->
+        <dropColumn columnName="name" tableName="organization"/>
     </changeSet>
 
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/migrations/5-Add_Org_Name_Translation_Table.xml
+++ b/src/main/resources/db/changelog/migrations/5-Add_Org_Name_Translation_Table.xml
@@ -13,7 +13,7 @@
             <column name="language_code" type="CHAR(2)">
                 <constraints nullable="false"/>
             </column>
-            <column name="value" type="VARCHAR(250)">
+            <column name="name" type="VARCHAR(250)">
                 <constraints nullable="false"/>
             </column>
             <column name="organization_id" type="integer">

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,0 +1,1 @@
+organization.constraint.required.name=An organization must have at least one name

--- a/src/test/java/ca/gc/aafc/agent/api/OrganizationNameTranslationsRestIT.java
+++ b/src/test/java/ca/gc/aafc/agent/api/OrganizationNameTranslationsRestIT.java
@@ -165,7 +165,6 @@ public class OrganizationNameTranslationsRestIT extends BaseRestAssuredTest {
 
   private void validateResultWithId(OrganizationDto expectedDTO, String id) {
     ValidatableResponse response = sendGet("organization", id);response.log().all(true);
-    response.body("data.attributes.name", Matchers.equalTo(expectedDTO.getName()));
     response.body(
       "data.attributes.nameTranslations",
       Matchers.hasSize(expectedDTO.getNameTranslations().size()));
@@ -193,7 +192,6 @@ public class OrganizationNameTranslationsRestIT extends BaseRestAssuredTest {
 
   private static OrganizationDto newOrgDTO() {
     OrganizationDto dto = new OrganizationDto();
-    dto.setName(RandomStringUtils.randomAlphabetic(5));
     OrganizationNameTranslationDto translation = OrganizationNameTranslationDto.builder()
       .value(RandomStringUtils.randomAlphabetic(5))
       .languageCode(RandomStringUtils.randomAlphabetic(2)).build();

--- a/src/test/java/ca/gc/aafc/agent/api/OrganizationNameTranslationsRestIT.java
+++ b/src/test/java/ca/gc/aafc/agent/api/OrganizationNameTranslationsRestIT.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 @SpringBootTest(
   classes = AgentModuleApiLauncher.class,
@@ -59,19 +60,9 @@ public class OrganizationNameTranslationsRestIT extends BaseRestAssuredTest {
     String id = super.sendPost("organization", mapOrg(dto))
       .extract().jsonPath().getString("data.id");
 
-    Assertions.assertEquals(
-      1,
-      service.findAll(OrganizationNameTranslation.class,
-        (criteriaBuilder, organizationNameTranslationRoot) -> new Predicate[0],
-        null, 0, 10).size());
-
+    Assertions.assertEquals(1, fetchTranslationsCountForOrg(id));
     sendDelete("organization", id);
-
-    Assertions.assertEquals(
-      0,
-      service.findAll(OrganizationNameTranslation.class,
-        (criteriaBuilder, organizationNameTranslationRoot) -> new Predicate[0],
-        null, 0, 10).size());
+    Assertions.assertEquals(0, fetchTranslationsCountForOrg(id));
   }
 
   @Test
@@ -199,4 +190,10 @@ public class OrganizationNameTranslationsRestIT extends BaseRestAssuredTest {
     return dto;
   }
 
+  private long fetchTranslationsCountForOrg(String id) {
+    return service.findAll(OrganizationNameTranslation.class,
+      (criteriaBuilder, organizationNameTranslationRoot) -> new Predicate[0],
+      null, 0, 1000).stream().
+      filter(t -> t.getOrganization().getUuid().equals(UUID.fromString(id))).count();
+  }
 }

--- a/src/test/java/ca/gc/aafc/agent/api/OrganizationNameTranslationsRestIT.java
+++ b/src/test/java/ca/gc/aafc/agent/api/OrganizationNameTranslationsRestIT.java
@@ -1,6 +1,7 @@
 package ca.gc.aafc.agent.api;
 
 import ca.gc.aafc.agent.api.dto.OrganizationDto;
+import ca.gc.aafc.agent.api.dto.OrganizationNameTranslationDto;
 import ca.gc.aafc.agent.api.entities.Organization;
 import ca.gc.aafc.agent.api.entities.OrganizationNameTranslation;
 import ca.gc.aafc.dina.service.DinaService;
@@ -81,7 +82,7 @@ public class OrganizationNameTranslationsRestIT extends BaseRestAssuredTest {
       .extract().jsonPath().getString("data.id");
 
     dto.getNameTranslations()
-      .add(OrganizationNameTranslation.builder().languageCode("ne").value("new Val").build());
+      .add(OrganizationNameTranslationDto.builder().languageCode("ne").value("new Val").build());
 
     sendPatch("organization", id, ImmutableMap.of(
       "data", ImmutableMap.of(
@@ -96,7 +97,7 @@ public class OrganizationNameTranslationsRestIT extends BaseRestAssuredTest {
   void patch_TranslationRemovedFromOrg_TranslationRemoved() {
     OrganizationDto dto = newOrgDTO();
     dto.getNameTranslations()
-      .add(OrganizationNameTranslation.builder().languageCode("ne").value("new Val").build());
+      .add(OrganizationNameTranslationDto.builder().languageCode("ne").value("new Val").build());
 
     String id = super.sendPost("organization", mapOrg(dto))
       .extract().jsonPath().getString("data.id");
@@ -163,7 +164,7 @@ public class OrganizationNameTranslationsRestIT extends BaseRestAssuredTest {
   }
 
   private void validateResultWithId(OrganizationDto expectedDTO, String id) {
-    ValidatableResponse response = sendGet("organization", id);
+    ValidatableResponse response = sendGet("organization", id);response.log().all(true);
     response.body("data.attributes.name", Matchers.equalTo(expectedDTO.getName()));
     response.body(
       "data.attributes.nameTranslations",
@@ -172,10 +173,10 @@ public class OrganizationNameTranslationsRestIT extends BaseRestAssuredTest {
   }
 
   private void validateTranslations(
-    ValidatableResponse response, List<OrganizationNameTranslation> translations
+    ValidatableResponse response, List<OrganizationNameTranslationDto> translations
   ) {
     for (int i = 0; i < translations.size(); i++) {
-      OrganizationNameTranslation expectedTranslation = translations.get(i);
+      OrganizationNameTranslationDto expectedTranslation = translations.get(i);
       response.body(
         "data.attributes.nameTranslations[" + i + "].languageCode",
         Matchers.equalTo(expectedTranslation.getLanguageCode()));
@@ -193,7 +194,7 @@ public class OrganizationNameTranslationsRestIT extends BaseRestAssuredTest {
   private static OrganizationDto newOrgDTO() {
     OrganizationDto dto = new OrganizationDto();
     dto.setName(RandomStringUtils.randomAlphabetic(5));
-    OrganizationNameTranslation translation = OrganizationNameTranslation.builder()
+    OrganizationNameTranslationDto translation = OrganizationNameTranslationDto.builder()
       .value(RandomStringUtils.randomAlphabetic(5))
       .languageCode(RandomStringUtils.randomAlphabetic(2)).build();
     dto.setNameTranslations(new ArrayList<>(Collections.singletonList(translation)));

--- a/src/test/java/ca/gc/aafc/agent/api/OrganizationNameTranslationsRestIT.java
+++ b/src/test/java/ca/gc/aafc/agent/api/OrganizationNameTranslationsRestIT.java
@@ -51,6 +51,13 @@ public class OrganizationNameTranslationsRestIT extends BaseRestAssuredTest {
   }
 
   @Test
+  void post_WithNoNames_ReturnsBadRequest() {
+    OrganizationDto expected = newOrgDTO();
+    expected.getNames().clear();
+    super.sendPost("organization", mapOrg(expected), 400);
+  }
+
+  @Test
   void delete_OrgDeleted_OrphansRemoved() {
     OrganizationDto dto = newOrgDTO();
     String id = JsonAPITestHelper.extractId(super.sendPost("organization", mapOrg(dto)));
@@ -94,7 +101,7 @@ public class OrganizationNameTranslationsRestIT extends BaseRestAssuredTest {
   }
 
   @Test
-  void patch_EmptyTranslationsListSubmitted_AllTranslationsRemoved() {
+  void patch_ToRemoveAllNames_ReturnsBadRequest() {
     OrganizationDto dto = newOrgDTO();
     String id = JsonAPITestHelper.extractId(super.sendPost("organization", mapOrg(dto)));
 
@@ -102,25 +109,7 @@ public class OrganizationNameTranslationsRestIT extends BaseRestAssuredTest {
       "data", ImmutableMap.of(
         "type", "organization",
         "attributes", ImmutableMap.of("names", Collections.emptyList())
-      )));
-
-    dto.getNames().clear();
-    validateResultWithId(dto, id);
-  }
-
-  @Test
-  void patch_NullTranslationsListSubmitted_AllTranslationsRemoved() {
-    OrganizationDto dto = newOrgDTO();
-    String id = JsonAPITestHelper.extractId(super.sendPost("organization", mapOrg(dto)));
-
-    sendPatch("organization", id, ImmutableMap.of(
-      "data", ImmutableMap.of(
-        "type", "organization",
-        "attributes", Collections.singletonMap("names", null)
-      )));
-
-    dto.getNames().clear();
-    validateResultWithId(dto, id);
+      )), 400);
   }
 
   @Test

--- a/src/test/java/ca/gc/aafc/agent/api/OrganizationNameTranslationsRestIT.java
+++ b/src/test/java/ca/gc/aafc/agent/api/OrganizationNameTranslationsRestIT.java
@@ -42,7 +42,7 @@ public class OrganizationNameTranslationsRestIT extends BaseRestAssuredTest {
   }
 
   @Test
-  void post_nameTranslationsPersisted() {
+  void post_OrgPostedWithTranslations_TranslationsPersisted() {
     OrganizationDto expected = newOrgDTO();
 
     String id = super.sendPost("organization", mapOrg(expected))
@@ -52,7 +52,7 @@ public class OrganizationNameTranslationsRestIT extends BaseRestAssuredTest {
   }
 
   @Test
-  void delete_nameTranslationsRemoved() {
+  void delete_OrgDeleted_OrphansRemoved() {
     OrganizationDto dto = newOrgDTO();
 
     String id = super.sendPost("organization", mapOrg(dto))
@@ -74,7 +74,7 @@ public class OrganizationNameTranslationsRestIT extends BaseRestAssuredTest {
   }
 
   @Test
-  void patch_nameTranslationAdded() {
+  void patch_OrgUpdatedWithTranslation_TranslationAdded() {
     OrganizationDto dto = newOrgDTO();
 
     String id = super.sendPost("organization", mapOrg(dto))
@@ -93,7 +93,7 @@ public class OrganizationNameTranslationsRestIT extends BaseRestAssuredTest {
   }
 
   @Test
-  void patch_nameTranslationRemoved() {
+  void patch_TranslationRemovedFromOrg_TranslationRemoved() {
     OrganizationDto dto = newOrgDTO();
     dto.getNameTranslations()
       .add(OrganizationNameTranslation.builder().language("ne").value("new Val").build());
@@ -113,7 +113,7 @@ public class OrganizationNameTranslationsRestIT extends BaseRestAssuredTest {
   }
 
   @Test
-  void patch_EmptyTranslationsListSubmitted_TranslationsRemoved() {
+  void patch_EmptyTranslationsListSubmitted_AllTranslationsRemoved() {
     OrganizationDto dto = newOrgDTO();
 
     String id = super.sendPost("organization", mapOrg(dto))
@@ -130,7 +130,7 @@ public class OrganizationNameTranslationsRestIT extends BaseRestAssuredTest {
   }
 
   @Test
-  void patch_NullTranslationsListSubmitted_TranslationsRemoved() {
+  void patch_NullTranslationsListSubmitted_AllTranslationsRemoved() {
     OrganizationDto dto = newOrgDTO();
 
     String id = super.sendPost("organization", mapOrg(dto))
@@ -164,7 +164,6 @@ public class OrganizationNameTranslationsRestIT extends BaseRestAssuredTest {
 
   private void validateResultWithId(OrganizationDto expectedDTO, String id) {
     ValidatableResponse response = sendGet("organization", id);
-    response.log().all(true);//TODO remove me
     response.body("data.attributes.name", Matchers.equalTo(expectedDTO.getName()));
     response.body(
       "data.attributes.nameTranslations",

--- a/src/test/java/ca/gc/aafc/agent/api/OrganizationNameTranslationsRestIT.java
+++ b/src/test/java/ca/gc/aafc/agent/api/OrganizationNameTranslationsRestIT.java
@@ -81,7 +81,7 @@ public class OrganizationNameTranslationsRestIT extends BaseRestAssuredTest {
       .extract().jsonPath().getString("data.id");
 
     dto.getNameTranslations()
-      .add(OrganizationNameTranslation.builder().language("ne").value("new Val").build());
+      .add(OrganizationNameTranslation.builder().languageCode("ne").value("new Val").build());
 
     sendPatch("organization", id, ImmutableMap.of(
       "data", ImmutableMap.of(
@@ -96,7 +96,7 @@ public class OrganizationNameTranslationsRestIT extends BaseRestAssuredTest {
   void patch_TranslationRemovedFromOrg_TranslationRemoved() {
     OrganizationDto dto = newOrgDTO();
     dto.getNameTranslations()
-      .add(OrganizationNameTranslation.builder().language("ne").value("new Val").build());
+      .add(OrganizationNameTranslation.builder().languageCode("ne").value("new Val").build());
 
     String id = super.sendPost("organization", mapOrg(dto))
       .extract().jsonPath().getString("data.id");
@@ -177,8 +177,8 @@ public class OrganizationNameTranslationsRestIT extends BaseRestAssuredTest {
     for (int i = 0; i < translations.size(); i++) {
       OrganizationNameTranslation expectedTranslation = translations.get(i);
       response.body(
-        "data.attributes.nameTranslations[" + i + "].language",
-        Matchers.equalTo(expectedTranslation.getLanguage()));
+        "data.attributes.nameTranslations[" + i + "].languageCode",
+        Matchers.equalTo(expectedTranslation.getLanguageCode()));
       response.body(
         "data.attributes.nameTranslations[" + i + "].value",
         Matchers.equalTo(expectedTranslation.getValue()));
@@ -195,7 +195,7 @@ public class OrganizationNameTranslationsRestIT extends BaseRestAssuredTest {
     dto.setName(RandomStringUtils.randomAlphabetic(5));
     OrganizationNameTranslation translation = OrganizationNameTranslation.builder()
       .value(RandomStringUtils.randomAlphabetic(5))
-      .language(RandomStringUtils.randomAlphabetic(2)).build();
+      .languageCode(RandomStringUtils.randomAlphabetic(2)).build();
     dto.setNameTranslations(new ArrayList<>(Collections.singletonList(translation)));
     return dto;
   }

--- a/src/test/java/ca/gc/aafc/agent/api/OrganizationNameTranslationsRestIT.java
+++ b/src/test/java/ca/gc/aafc/agent/api/OrganizationNameTranslationsRestIT.java
@@ -81,7 +81,7 @@ public class OrganizationNameTranslationsRestIT extends BaseRestAssuredTest {
     String id = super.sendPost("organization", mapOrg(dto))
       .extract().jsonPath().getString("data.id");
 
-    dto.getNameTranslations()
+    dto.getNames()
       .add(OrganizationNameTranslationDto.builder().languageCode("ne").value("new Val").build());
 
     sendPatch("organization", id, ImmutableMap.of(
@@ -96,13 +96,13 @@ public class OrganizationNameTranslationsRestIT extends BaseRestAssuredTest {
   @Test
   void patch_TranslationRemovedFromOrg_TranslationRemoved() {
     OrganizationDto dto = newOrgDTO();
-    dto.getNameTranslations()
+    dto.getNames()
       .add(OrganizationNameTranslationDto.builder().languageCode("ne").value("new Val").build());
 
     String id = super.sendPost("organization", mapOrg(dto))
       .extract().jsonPath().getString("data.id");
 
-    dto.getNameTranslations().remove(0);
+    dto.getNames().remove(0);
 
     sendPatch("organization", id, ImmutableMap.of(
       "data", ImmutableMap.of(
@@ -123,10 +123,10 @@ public class OrganizationNameTranslationsRestIT extends BaseRestAssuredTest {
     sendPatch("organization", id, ImmutableMap.of(
       "data", ImmutableMap.of(
         "type", "organization",
-        "attributes", ImmutableMap.of("nameTranslations", Collections.emptyList())
+        "attributes", ImmutableMap.of("names", Collections.emptyList())
       )));
 
-    dto.getNameTranslations().clear();
+    dto.getNames().clear();
     validateResultWithId(dto, id);
   }
 
@@ -140,10 +140,10 @@ public class OrganizationNameTranslationsRestIT extends BaseRestAssuredTest {
     sendPatch("organization", id, ImmutableMap.of(
       "data", ImmutableMap.of(
         "type", "organization",
-        "attributes", Collections.singletonMap("nameTranslations", null)
+        "attributes", Collections.singletonMap("names", null)
       )));
 
-    dto.getNameTranslations().clear();
+    dto.getNames().clear();
     validateResultWithId(dto, id);
   }
 
@@ -166,9 +166,9 @@ public class OrganizationNameTranslationsRestIT extends BaseRestAssuredTest {
   private void validateResultWithId(OrganizationDto expectedDTO, String id) {
     ValidatableResponse response = sendGet("organization", id);response.log().all(true);
     response.body(
-      "data.attributes.nameTranslations",
-      Matchers.hasSize(expectedDTO.getNameTranslations().size()));
-    validateTranslations(response, expectedDTO.getNameTranslations());
+      "data.attributes.names",
+      Matchers.hasSize(expectedDTO.getNames().size()));
+    validateTranslations(response, expectedDTO.getNames());
   }
 
   private void validateTranslations(
@@ -177,10 +177,10 @@ public class OrganizationNameTranslationsRestIT extends BaseRestAssuredTest {
     for (int i = 0; i < translations.size(); i++) {
       OrganizationNameTranslationDto expectedTranslation = translations.get(i);
       response.body(
-        "data.attributes.nameTranslations[" + i + "].languageCode",
+        "data.attributes.names[" + i + "].languageCode",
         Matchers.equalTo(expectedTranslation.getLanguageCode()));
       response.body(
-        "data.attributes.nameTranslations[" + i + "].value",
+        "data.attributes.names[" + i + "].value",
         Matchers.equalTo(expectedTranslation.getValue()));
     }
   }
@@ -195,7 +195,7 @@ public class OrganizationNameTranslationsRestIT extends BaseRestAssuredTest {
     OrganizationNameTranslationDto translation = OrganizationNameTranslationDto.builder()
       .value(RandomStringUtils.randomAlphabetic(5))
       .languageCode(RandomStringUtils.randomAlphabetic(2)).build();
-    dto.setNameTranslations(new ArrayList<>(Collections.singletonList(translation)));
+    dto.setNames(new ArrayList<>(Collections.singletonList(translation)));
     return dto;
   }
 

--- a/src/test/java/ca/gc/aafc/agent/api/OrganizationNameTranslationsRestIT.java
+++ b/src/test/java/ca/gc/aafc/agent/api/OrganizationNameTranslationsRestIT.java
@@ -32,12 +32,12 @@ import java.util.Map;
 @Transactional
 @ContextConfiguration(initializers = {PostgresTestContainerInitializer.class})
 @TestPropertySource(properties = "spring.config.additional-location=classpath:application-test.yml")
-public class OrganizationRestIT extends BaseRestAssuredTest {
+public class OrganizationNameTranslationsRestIT extends BaseRestAssuredTest {
 
   @Inject
   private DinaService<Organization> service;
 
-  protected OrganizationRestIT() {
+  protected OrganizationNameTranslationsRestIT() {
     super("/api/v1/");
   }
 

--- a/src/test/java/ca/gc/aafc/agent/api/OrganizationNameTranslationsRestIT.java
+++ b/src/test/java/ca/gc/aafc/agent/api/OrganizationNameTranslationsRestIT.java
@@ -82,7 +82,7 @@ public class OrganizationNameTranslationsRestIT extends BaseRestAssuredTest {
       .extract().jsonPath().getString("data.id");
 
     dto.getNames()
-      .add(OrganizationNameTranslationDto.builder().languageCode("ne").value("new Val").build());
+      .add(OrganizationNameTranslationDto.builder().languageCode("ne").name("new Val").build());
 
     sendPatch("organization", id, ImmutableMap.of(
       "data", ImmutableMap.of(
@@ -97,7 +97,7 @@ public class OrganizationNameTranslationsRestIT extends BaseRestAssuredTest {
   void patch_TranslationRemovedFromOrg_TranslationRemoved() {
     OrganizationDto dto = newOrgDTO();
     dto.getNames()
-      .add(OrganizationNameTranslationDto.builder().languageCode("ne").value("new Val").build());
+      .add(OrganizationNameTranslationDto.builder().languageCode("ne").name("new Val").build());
 
     String id = super.sendPost("organization", mapOrg(dto))
       .extract().jsonPath().getString("data.id");
@@ -164,7 +164,7 @@ public class OrganizationNameTranslationsRestIT extends BaseRestAssuredTest {
   }
 
   private void validateResultWithId(OrganizationDto expectedDTO, String id) {
-    ValidatableResponse response = sendGet("organization", id);response.log().all(true);
+    ValidatableResponse response = sendGet("organization", id);
     response.body(
       "data.attributes.names",
       Matchers.hasSize(expectedDTO.getNames().size()));
@@ -180,8 +180,8 @@ public class OrganizationNameTranslationsRestIT extends BaseRestAssuredTest {
         "data.attributes.names[" + i + "].languageCode",
         Matchers.equalTo(expectedTranslation.getLanguageCode()));
       response.body(
-        "data.attributes.names[" + i + "].value",
-        Matchers.equalTo(expectedTranslation.getValue()));
+        "data.attributes.names[" + i + "].name",
+        Matchers.equalTo(expectedTranslation.getName()));
     }
   }
 
@@ -193,7 +193,7 @@ public class OrganizationNameTranslationsRestIT extends BaseRestAssuredTest {
   private static OrganizationDto newOrgDTO() {
     OrganizationDto dto = new OrganizationDto();
     OrganizationNameTranslationDto translation = OrganizationNameTranslationDto.builder()
-      .value(RandomStringUtils.randomAlphabetic(5))
+      .name(RandomStringUtils.randomAlphabetic(5))
       .languageCode(RandomStringUtils.randomAlphabetic(2)).build();
     dto.setNames(new ArrayList<>(Collections.singletonList(translation)));
     return dto;

--- a/src/test/java/ca/gc/aafc/agent/api/OrganizationNameTranslationsRestIT.java
+++ b/src/test/java/ca/gc/aafc/agent/api/OrganizationNameTranslationsRestIT.java
@@ -46,19 +46,14 @@ public class OrganizationNameTranslationsRestIT extends BaseRestAssuredTest {
   @Test
   void post_OrgPostedWithTranslations_TranslationsPersisted() {
     OrganizationDto expected = newOrgDTO();
-
-    String id = super.sendPost("organization", mapOrg(expected))
-      .extract().jsonPath().getString("data.id");
-
+    String id = JsonAPITestHelper.extractId(super.sendPost("organization", mapOrg(expected)));
     validateResultWithId(expected, id);
   }
 
   @Test
   void delete_OrgDeleted_OrphansRemoved() {
     OrganizationDto dto = newOrgDTO();
-
-    String id = super.sendPost("organization", mapOrg(dto))
-      .extract().jsonPath().getString("data.id");
+    String id = JsonAPITestHelper.extractId(super.sendPost("organization", mapOrg(dto)));
 
     Assertions.assertEquals(1, fetchTranslationsCountForOrg(id));
     sendDelete("organization", id);
@@ -68,13 +63,10 @@ public class OrganizationNameTranslationsRestIT extends BaseRestAssuredTest {
   @Test
   void patch_OrgUpdatedWithTranslation_TranslationAdded() {
     OrganizationDto dto = newOrgDTO();
-
-    String id = super.sendPost("organization", mapOrg(dto))
-      .extract().jsonPath().getString("data.id");
+    String id = JsonAPITestHelper.extractId(super.sendPost("organization", mapOrg(dto)));
 
     dto.getNames()
       .add(OrganizationNameTranslationDto.builder().languageCode("ne").name("new Val").build());
-
     sendPatch("organization", id, ImmutableMap.of(
       "data", ImmutableMap.of(
         "type", "organization",
@@ -89,12 +81,9 @@ public class OrganizationNameTranslationsRestIT extends BaseRestAssuredTest {
     OrganizationDto dto = newOrgDTO();
     dto.getNames()
       .add(OrganizationNameTranslationDto.builder().languageCode("ne").name("new Val").build());
-
-    String id = super.sendPost("organization", mapOrg(dto))
-      .extract().jsonPath().getString("data.id");
+    String id = JsonAPITestHelper.extractId(super.sendPost("organization", mapOrg(dto)));
 
     dto.getNames().remove(0);
-
     sendPatch("organization", id, ImmutableMap.of(
       "data", ImmutableMap.of(
         "type", "organization",
@@ -107,9 +96,7 @@ public class OrganizationNameTranslationsRestIT extends BaseRestAssuredTest {
   @Test
   void patch_EmptyTranslationsListSubmitted_AllTranslationsRemoved() {
     OrganizationDto dto = newOrgDTO();
-
-    String id = super.sendPost("organization", mapOrg(dto))
-      .extract().jsonPath().getString("data.id");
+    String id = JsonAPITestHelper.extractId(super.sendPost("organization", mapOrg(dto)));
 
     sendPatch("organization", id, ImmutableMap.of(
       "data", ImmutableMap.of(
@@ -124,9 +111,7 @@ public class OrganizationNameTranslationsRestIT extends BaseRestAssuredTest {
   @Test
   void patch_NullTranslationsListSubmitted_AllTranslationsRemoved() {
     OrganizationDto dto = newOrgDTO();
-
-    String id = super.sendPost("organization", mapOrg(dto))
-      .extract().jsonPath().getString("data.id");
+    String id = JsonAPITestHelper.extractId(super.sendPost("organization", mapOrg(dto)));
 
     sendPatch("organization", id, ImmutableMap.of(
       "data", ImmutableMap.of(
@@ -141,9 +126,7 @@ public class OrganizationNameTranslationsRestIT extends BaseRestAssuredTest {
   @Test
   void patch_EmptyPatch_TranslationsRemain() {
     OrganizationDto expected = newOrgDTO();
-
-    String id = super.sendPost("organization", mapOrg(expected))
-      .extract().jsonPath().getString("data.id");
+    String id = JsonAPITestHelper.extractId(super.sendPost("organization", mapOrg(expected)));
 
     sendPatch("organization", id, ImmutableMap.of(
       "data", ImmutableMap.of(

--- a/src/test/java/ca/gc/aafc/agent/api/OrganizationRestIT.java
+++ b/src/test/java/ca/gc/aafc/agent/api/OrganizationRestIT.java
@@ -5,13 +5,17 @@ import ca.gc.aafc.agent.api.entities.OrganizationNameTranslation;
 import ca.gc.aafc.dina.testsupport.BaseRestAssuredTest;
 import ca.gc.aafc.dina.testsupport.PostgresTestContainerInitializer;
 import ca.gc.aafc.dina.testsupport.jsonapi.JsonAPITestHelper;
+import io.restassured.response.ValidatableResponse;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.shaded.org.apache.commons.lang.RandomStringUtils;
 
 import javax.transaction.Transactional;
 import java.util.Collections;
+import java.util.Map;
 
 @SpringBootTest(
   classes = AgentModuleApiLauncher.class,
@@ -27,21 +31,47 @@ public class OrganizationRestIT extends BaseRestAssuredTest {
   }
 
   @Test
-  void post_customFieldsResolved() {
+  void post_nameTranslationsPersisted() {
+    OrganizationDto dto = newOrgDTO();
+
+    String id = super.sendPost("organization", mapOrg(dto))
+      .extract().jsonPath().getString("data.id");
+
+    ValidatableResponse response = sendGet("organization", id);
+    response.body("data.attributes.nameTranslations", Matchers.hasSize(1));
+    OrganizationNameTranslation expected = dto.getNameTranslations().get(0);
+    response.body(
+      "data.attributes.nameTranslations[0].language",
+      Matchers.equalTo(expected.getLanguage()));
+    response.body(
+      "data.attributes.nameTranslations[0].value",
+      Matchers.equalTo(expected.getValue()));
+    response.log().all(true);//TODO
+  }
+
+  @Test
+  void delete_nameTranslationsRemoved() {
+    OrganizationDto dto = newOrgDTO();
+
+    String id = super.sendPost("organization", mapOrg(dto))
+      .extract().jsonPath().getString("data.id");
+
+    sendGet("organization", id).log().all(true);//TODO
+  }
+
+  private Map<String, Object> mapOrg(OrganizationDto dto) {
+    return JsonAPITestHelper.toJsonAPIMap(
+      "organization", JsonAPITestHelper.toAttributeMap(dto), null, null);
+  }
+
+  private OrganizationDto newOrgDTO() {
     OrganizationDto dto = new OrganizationDto();
-    dto.setName("d");
-    dto.setNameTranslations(Collections.singletonList(OrganizationNameTranslation.builder()
-      .value("testValue").language("testlang").build()));
-
-    String id = super.sendPost(
-      "organization",
-      JsonAPITestHelper.toJsonAPIMap(
-        "organization", JsonAPITestHelper.toAttributeMap(dto), null, null))
-      .extract()
-      .jsonPath()
-      .getString("data.id");
-
-    sendGet("organization", id).log().all(true);
+    dto.setName(RandomStringUtils.randomAlphabetic(5));
+    OrganizationNameTranslation translation = OrganizationNameTranslation.builder()
+      .value(RandomStringUtils.randomAlphabetic(5))
+      .language(RandomStringUtils.randomAlphabetic(5)).build();
+    dto.setNameTranslations(Collections.singletonList(translation));
+    return dto;
   }
 
 }

--- a/src/test/java/ca/gc/aafc/agent/api/OrganizationRestIT.java
+++ b/src/test/java/ca/gc/aafc/agent/api/OrganizationRestIT.java
@@ -1,18 +1,23 @@
 package ca.gc.aafc.agent.api;
 
 import ca.gc.aafc.agent.api.dto.OrganizationDto;
+import ca.gc.aafc.agent.api.entities.Organization;
 import ca.gc.aafc.agent.api.entities.OrganizationNameTranslation;
+import ca.gc.aafc.dina.service.DinaService;
 import ca.gc.aafc.dina.testsupport.BaseRestAssuredTest;
 import ca.gc.aafc.dina.testsupport.PostgresTestContainerInitializer;
 import ca.gc.aafc.dina.testsupport.jsonapi.JsonAPITestHelper;
 import io.restassured.response.ValidatableResponse;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.testcontainers.shaded.org.apache.commons.lang.RandomStringUtils;
 
+import javax.inject.Inject;
+import javax.persistence.criteria.Predicate;
 import javax.transaction.Transactional;
 import java.util.Collections;
 import java.util.Map;
@@ -25,6 +30,9 @@ import java.util.Map;
 @ContextConfiguration(initializers = {PostgresTestContainerInitializer.class})
 @TestPropertySource(properties = "spring.config.additional-location=classpath:application-test.yml")
 public class OrganizationRestIT extends BaseRestAssuredTest {
+
+  @Inject
+  private DinaService<Organization> service;
 
   protected OrganizationRestIT() {
     super("/api/v1/");
@@ -56,7 +64,19 @@ public class OrganizationRestIT extends BaseRestAssuredTest {
     String id = super.sendPost("organization", mapOrg(dto))
       .extract().jsonPath().getString("data.id");
 
-    sendGet("organization", id).log().all(true);//TODO
+    Assertions.assertEquals(
+      1,
+      service.findAll(OrganizationNameTranslation.class,
+        (criteriaBuilder, organizationNameTranslationRoot) -> new Predicate[0],
+        null, 0, 10).size());
+
+    sendDelete("organization", id);
+
+    Assertions.assertEquals(
+      0,
+      service.findAll(OrganizationNameTranslation.class,
+        (criteriaBuilder, organizationNameTranslationRoot) -> new Predicate[0],
+        null, 0, 10).size());
   }
 
   private Map<String, Object> mapOrg(OrganizationDto dto) {

--- a/src/test/java/ca/gc/aafc/agent/api/OrganizationRestIT.java
+++ b/src/test/java/ca/gc/aafc/agent/api/OrganizationRestIT.java
@@ -1,6 +1,7 @@
 package ca.gc.aafc.agent.api;
 
 import ca.gc.aafc.agent.api.dto.OrganizationDto;
+import ca.gc.aafc.agent.api.entities.OrganizationNameTranslation;
 import ca.gc.aafc.dina.testsupport.BaseRestAssuredTest;
 import ca.gc.aafc.dina.testsupport.PostgresTestContainerInitializer;
 import ca.gc.aafc.dina.testsupport.jsonapi.JsonAPITestHelper;
@@ -10,6 +11,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
 import javax.transaction.Transactional;
+import java.util.Collections;
 
 @SpringBootTest(
   classes = AgentModuleApiLauncher.class,
@@ -25,9 +27,11 @@ public class OrganizationRestIT extends BaseRestAssuredTest {
   }
 
   @Test
-  void post_maps() {
+  void post_customFieldsResolved() {
     OrganizationDto dto = new OrganizationDto();
     dto.setName("d");
+    dto.setNameTranslations(Collections.singletonList(OrganizationNameTranslation.builder()
+      .value("testValue").language("testlang").build()));
 
     String id = super.sendPost(
       "organization",

--- a/src/test/java/ca/gc/aafc/agent/api/OrganizationRestIT.java
+++ b/src/test/java/ca/gc/aafc/agent/api/OrganizationRestIT.java
@@ -22,6 +22,7 @@ import javax.persistence.criteria.Predicate;
 import javax.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 @SpringBootTest(
@@ -113,14 +114,22 @@ public class OrganizationRestIT extends BaseRestAssuredTest {
     response.body(
       "data.attributes.nameTranslations",
       Matchers.hasSize(expectedDTO.getNameTranslations().size()));
-    OrganizationNameTranslation expectedTranslation = expectedDTO.getNameTranslations().get(0);//TODO validate all expected translations
-    response.body(
-      "data.attributes.nameTranslations[0].language",
-      Matchers.equalTo(expectedTranslation.getLanguage()));
-    response.body(
-      "data.attributes.nameTranslations[0].value",
-      Matchers.equalTo(expectedTranslation.getValue()));
+    validateTranslations(response, expectedDTO.getNameTranslations());
     response.log().all(true);//TODO remove me
+  }
+
+  private void validateTranslations(
+    ValidatableResponse response, List<OrganizationNameTranslation> translations
+  ) {
+    for (int i = 0; i < translations.size(); i++) {
+      OrganizationNameTranslation expectedTranslation = translations.get(i);
+      response.body(
+        "data.attributes.nameTranslations[" + i + "].language",
+        Matchers.equalTo(expectedTranslation.getLanguage()));
+      response.body(
+        "data.attributes.nameTranslations[" + i + "].value",
+        Matchers.equalTo(expectedTranslation.getValue()));
+    }
   }
 
   private static Map<String, Object> mapOrg(OrganizationDto dto) {

--- a/src/test/java/ca/gc/aafc/agent/api/OrganizationRestIT.java
+++ b/src/test/java/ca/gc/aafc/agent/api/OrganizationRestIT.java
@@ -1,0 +1,43 @@
+package ca.gc.aafc.agent.api;
+
+import ca.gc.aafc.agent.api.dto.OrganizationDto;
+import ca.gc.aafc.dina.testsupport.BaseRestAssuredTest;
+import ca.gc.aafc.dina.testsupport.PostgresTestContainerInitializer;
+import ca.gc.aafc.dina.testsupport.jsonapi.JsonAPITestHelper;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+import javax.transaction.Transactional;
+
+@SpringBootTest(
+  classes = AgentModuleApiLauncher.class,
+  webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
+)
+@Transactional
+@ContextConfiguration(initializers = {PostgresTestContainerInitializer.class})
+@TestPropertySource(properties = "spring.config.additional-location=classpath:application-test.yml")
+public class OrganizationRestIT extends BaseRestAssuredTest {
+
+  protected OrganizationRestIT() {
+    super("/api/v1/");
+  }
+
+  @Test
+  void post_maps() {
+    OrganizationDto dto = new OrganizationDto();
+    dto.setName("d");
+
+    String id = super.sendPost(
+      "organization",
+      JsonAPITestHelper.toJsonAPIMap(
+        "organization", JsonAPITestHelper.toAttributeMap(dto), null, null))
+      .extract()
+      .jsonPath()
+      .getString("data.id");
+
+    sendGet("organization", id).log().all(true);
+  }
+
+}

--- a/src/test/java/ca/gc/aafc/agent/api/OrganizationRestIT.java
+++ b/src/test/java/ca/gc/aafc/agent/api/OrganizationRestIT.java
@@ -81,7 +81,7 @@ public class OrganizationRestIT extends BaseRestAssuredTest {
       .extract().jsonPath().getString("data.id");
 
     dto.getNameTranslations()
-      .add(OrganizationNameTranslation.builder().language("new lang").value("new Val").build());
+      .add(OrganizationNameTranslation.builder().language("ne").value("new Val").build());
 
     sendPatch("organization", id, ImmutableMap.of(
       "data", ImmutableMap.of(
@@ -96,7 +96,7 @@ public class OrganizationRestIT extends BaseRestAssuredTest {
   void patch_nameTranslationRemoved() {
     OrganizationDto dto = newOrgDTO();
     dto.getNameTranslations()
-      .add(OrganizationNameTranslation.builder().language("new lang").value("new Val").build());
+      .add(OrganizationNameTranslation.builder().language("ne").value("new Val").build());
 
     String id = super.sendPost("organization", mapOrg(dto))
       .extract().jsonPath().getString("data.id");
@@ -196,7 +196,7 @@ public class OrganizationRestIT extends BaseRestAssuredTest {
     dto.setName(RandomStringUtils.randomAlphabetic(5));
     OrganizationNameTranslation translation = OrganizationNameTranslation.builder()
       .value(RandomStringUtils.randomAlphabetic(5))
-      .language(RandomStringUtils.randomAlphabetic(5)).build();
+      .language(RandomStringUtils.randomAlphabetic(2)).build();
     dto.setNameTranslations(new ArrayList<>(Collections.singletonList(translation)));
     return dto;
   }

--- a/src/test/java/ca/gc/aafc/agent/api/OrganizationRestIT.java
+++ b/src/test/java/ca/gc/aafc/agent/api/OrganizationRestIT.java
@@ -113,6 +113,40 @@ public class OrganizationRestIT extends BaseRestAssuredTest {
   }
 
   @Test
+  void patch_EmptyTranslationsListSubmitted_TranslationsRemoved() {
+    OrganizationDto dto = newOrgDTO();
+
+    String id = super.sendPost("organization", mapOrg(dto))
+      .extract().jsonPath().getString("data.id");
+
+    sendPatch("organization", id, ImmutableMap.of(
+      "data", ImmutableMap.of(
+        "type", "organization",
+        "attributes", ImmutableMap.of("nameTranslations", Collections.emptyList())
+      )));
+
+    dto.getNameTranslations().clear();
+    validateResultWithId(dto, id);
+  }
+
+  @Test
+  void patch_NullTranslationsListSubmitted_TranslationsRemoved() {
+    OrganizationDto dto = newOrgDTO();
+
+    String id = super.sendPost("organization", mapOrg(dto))
+      .extract().jsonPath().getString("data.id");
+
+    sendPatch("organization", id, ImmutableMap.of(
+      "data", ImmutableMap.of(
+        "type", "organization",
+        "attributes", Collections.singletonMap("nameTranslations", null)
+      )));
+
+    dto.getNameTranslations().clear();
+    validateResultWithId(dto, id);
+  }
+
+  @Test
   void patch_EmptyPatch_TranslationsRemain() {
     OrganizationDto expected = newOrgDTO();
 
@@ -129,7 +163,8 @@ public class OrganizationRestIT extends BaseRestAssuredTest {
   }
 
   private void validateResultWithId(OrganizationDto expectedDTO, String id) {
-    ValidatableResponse response = sendGet("organization", id);  response.log().all(true);//TODO remove me
+    ValidatableResponse response = sendGet("organization", id);
+    response.log().all(true);//TODO remove me
     response.body("data.attributes.name", Matchers.equalTo(expectedDTO.getName()));
     response.body(
       "data.attributes.nameTranslations",

--- a/src/test/java/ca/gc/aafc/agent/api/openapi/OrganizationOpenApiIT.java
+++ b/src/test/java/ca/gc/aafc/agent/api/openapi/OrganizationOpenApiIT.java
@@ -65,7 +65,6 @@ public class OrganizationOpenApiIT extends BaseRestAssuredTest {
       JsonAPITestHelper.toJsonAPIMap(
         "organization",
         new ImmutableMap.Builder<String, Object>()
-          .put("name", name)
           .put("aliases", aliases)
           .build(),
         null,
@@ -74,7 +73,6 @@ public class OrganizationOpenApiIT extends BaseRestAssuredTest {
     );
 
     response
-      .body("data.attributes.name", Matchers.equalTo(name))
       .body("data.attributes.aliases", Matchers.equalTo(aliases))
       .body("data.id", Matchers.notNullValue());
 

--- a/src/test/java/ca/gc/aafc/agent/api/repository/OrganizationResourceRepositoryIT.java
+++ b/src/test/java/ca/gc/aafc/agent/api/repository/OrganizationResourceRepositoryIT.java
@@ -48,13 +48,11 @@ public class OrganizationResourceRepositoryIT extends BaseIntegrationTest {
   @Test
   public void createOrganization_onSuccess_organizationPersisted() {
     OrganizationDto orgDto = new OrganizationDto();
-    orgDto.setName("test org");
     orgDto.setAliases(new String[] {"test alias"});
 
     UUID uuid = organizationRepository.create(orgDto).getUuid();
 
     Organization result = dbService.findUnique(Organization.class, "uuid", uuid);
-    assertEquals(orgDto.getName(), result.getName());
     assertArrayEquals(orgDto.getAliases(), result.getAliases());
     assertEquals(uuid, result.getUuid());
     assertEquals("user", result.getCreatedBy());
@@ -70,13 +68,11 @@ public class OrganizationResourceRepositoryIT extends BaseIntegrationTest {
       organizationUnderTest.getUuid(),
       new QuerySpec(OrganizationDto.class)
     );
-    updatedDto.setName(newName);
     updatedDto.setAliases(newAliases);
 
     organizationRepository.save(updatedDto);
 
     Organization result = dbService.findUnique(Organization.class, "uuid", updatedDto.getUuid());
-    assertEquals(newName, result.getName());
     assertArrayEquals(newAliases, result.getAliases());
   }
 
@@ -90,7 +86,6 @@ public class OrganizationResourceRepositoryIT extends BaseIntegrationTest {
       organizationUnderTest.getUuid(),
       new QuerySpec(OrganizationDto.class)
     );
-    updatedDto.setName(newName);
     updatedDto.setAliases(newAliases);
 
     Assertions.assertThrows(AccessDeniedException.class,()-> organizationRepository.save(updatedDto));
@@ -103,7 +98,6 @@ public class OrganizationResourceRepositoryIT extends BaseIntegrationTest {
       new QuerySpec(OrganizationDto.class)
     );
 
-    assertEquals(organizationUnderTest.getName(), result.getName());
     assertArrayEquals(organizationUnderTest.getAliases(), result.getAliases());
     assertEquals(organizationUnderTest.getUuid(), result.getUuid());
   }

--- a/src/test/java/ca/gc/aafc/agent/api/repository/PersonResourceRepositoryIT.java
+++ b/src/test/java/ca/gc/aafc/agent/api/repository/PersonResourceRepositoryIT.java
@@ -1,11 +1,14 @@
 package ca.gc.aafc.agent.api.repository;
 
 import static org.junit.Assert.assertNull;
+
+import ca.gc.aafc.agent.api.dto.OrganizationNameTranslationDto;
 import io.crnk.core.queryspec.IncludeRelationSpec;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -71,6 +74,8 @@ public class PersonResourceRepositoryIT extends BaseIntegrationTest {
     personDto.setEmail(TestableEntityFactory.generateRandomNameLettersOnly(5) + "@email.com");
 
     OrganizationDto organizationDto = new OrganizationDto();
+    organizationDto.setNames(Collections.singletonList(
+      OrganizationNameTranslationDto.builder().languageCode("te").name("name").build()));
     organizationDto.setUuid(UUID.randomUUID());
     
     organizationResourceRepository.create(organizationDto);

--- a/src/test/java/ca/gc/aafc/agent/api/repository/PersonResourceRepositoryIT.java
+++ b/src/test/java/ca/gc/aafc/agent/api/repository/PersonResourceRepositoryIT.java
@@ -34,7 +34,7 @@ import ca.gc.aafc.dina.testsupport.security.WithMockKeycloakUser;
 import io.crnk.core.queryspec.QuerySpec;
 
 /**
- * Test suite to validate the {@link PersonResourceRepository} correctly handles
+ * Test suite to validate the {@link PersonRepository} correctly handles
  * CRUD operations for the {@link Person} Entity.
  */
 @ExtendWith(SpringExtension.class)
@@ -71,7 +71,6 @@ public class PersonResourceRepositoryIT extends BaseIntegrationTest {
     personDto.setEmail(TestableEntityFactory.generateRandomNameLettersOnly(5) + "@email.com");
 
     OrganizationDto organizationDto = new OrganizationDto();
-    organizationDto.setName(TestableEntityFactory.generateRandomNameLettersOnly(5));
     organizationDto.setUuid(UUID.randomUUID());
     
     organizationResourceRepository.create(organizationDto);
@@ -158,7 +157,7 @@ public class PersonResourceRepositoryIT extends BaseIntegrationTest {
     assertEquals(personUnderTest.getDisplayName(), result.getDisplayName());
     assertEquals(personUnderTest.getEmail(), result.getEmail());
     assertEquals(personUnderTest.getUuid(), result.getUuid());
-    assertEquals(organizationUnderTest.getName(), result.getOrganizations().get(0).getName());
+    assertEquals(organizationUnderTest.getAliases()[0], result.getOrganizations().get(0).getAliases()[0]);
   }
   
 

--- a/src/test/java/ca/gc/aafc/agent/api/testsupport/factories/OrganizationFactory.java
+++ b/src/test/java/ca/gc/aafc/agent/api/testsupport/factories/OrganizationFactory.java
@@ -20,5 +20,5 @@ public class OrganizationFactory implements TestableEntityFactory<Organization> 
         TestableEntityFactory.generateRandomNameLettersOnly(15)
       });
   }
-  
+
 }

--- a/src/test/java/ca/gc/aafc/agent/api/testsupport/factories/OrganizationFactory.java
+++ b/src/test/java/ca/gc/aafc/agent/api/testsupport/factories/OrganizationFactory.java
@@ -15,7 +15,6 @@ public class OrganizationFactory implements TestableEntityFactory<Organization> 
   public static Organization.OrganizationBuilder newOrganization() {
     return Organization.builder()
       .uuid(UUID.randomUUID())
-      .name(TestableEntityFactory.generateRandomNameLettersOnly(15))
       .aliases(new String[] {
         TestableEntityFactory.generateRandomNameLettersOnly(15),
         TestableEntityFactory.generateRandomNameLettersOnly(15)


### PR DESCRIPTION
Adds multi language support for organization names.

Organizations no longer have a single name attribute.

An organization can only have one translation per language.

```
{
      "id": "6893d763-6402-4a11-a68b-8b5bf92c3812",
      "type": "organization",
      "links": {
        "self": "/api/v1/organization/6893d763-6402-4a11-a68b-8b5bf92c3812"
      },
      "attributes": {
        ...

        "names": [
          {
            "languageCode": "fo",
            "name": "bar"
          }
        ]
      }
 }
```