### PR TITLE
Support_21792_Remove_requirement_to_have_an_email_address

### DIFF
--- a/src/main/java/ca/gc/aafc/agent/api/entities/Person.java
+++ b/src/main/java/ca/gc/aafc/agent/api/entities/Person.java
@@ -57,7 +57,6 @@ public class Person implements DinaEntity {
   @NotBlank
   private String displayName;
 
-  @NotBlank
   @Email
   private String email;
 

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -7,4 +7,5 @@
   <include file="db/changelog/migrations/4-Add_person_to_organization_relationship_table.xml" />
   <include file="db/changelog/migrations/5-Add_Org_Name_Translation_Table.xml" />
   <include file="db/changelog/migrations/6-Add_givenNames_etc_person_table.xml" />
+  <include file="db/changelog/migrations/7-Make_person_email_nullable.xml" />
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/migrations/7-Make_person_email_nullable.xml
+++ b/src/main/resources/db/changelog/migrations/7-Make_person_email_nullable.xml
@@ -1,0 +1,12 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no" ?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd"
+        context="schema-change">
+
+    <changeSet context="schema-change" id="7-Make_person_email_nullable" author="poffm">
+        <dropNotNullConstraint tableName="person" columnName="email" />  
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/ca/gc/aafc/agent/api/testsupport/factories/PersonFactory.java
+++ b/src/test/java/ca/gc/aafc/agent/api/testsupport/factories/PersonFactory.java
@@ -23,8 +23,7 @@ public class PersonFactory implements TestableEntityFactory<Person> {
     return Person
       .builder()
       .uuid(UUID.randomUUID())
-      .displayName(TestableEntityFactory.generateRandomNameLettersOnly(15))
-      .email(TestableEntityFactory.generateRandomNameLettersOnly(5) + "@email.com");
+      .displayName(TestableEntityFactory.generateRandomNameLettersOnly(15));
   }
 
 }


### PR DESCRIPTION
-Removed NotBlank annotation from email field.
-Added Liquibase migration to remove not-null constraint.