### PR TITLE
29340 Avoid creating source artifact by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Publish to Maven Central (master branch only)
         if: ${{ github.ref == 'refs/heads/master' }}
-        run: mvn -DsignArtifacts=true --batch-mode javadoc:jar deploy
+        run: mvn -DsignArtifacts=true --batch-mode javadoc:jar source:jar deploy
         env:
           MAVEN_USERNAME: aafcbicoe
           MAVEN_CENTRAL_PW: ${{ secrets.MAVEN_CENTRAL_PW }}
@@ -59,6 +59,8 @@ jobs:
             version.txt
             target/agent-api-*.jar
             Dockerfile
+            !target/agent-api-*sources.jar
+            !target/agent-api-*javadoc.jar
 
   push:
     name: Build Docker Image and Push to DockerHub

--- a/pom.xml
+++ b/pom.xml
@@ -368,14 +368,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>attach-sources</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
The pom config will not create the source jar anymore be default. Also changes the CI config to avoid copying sources and javadoc jars to the Docker job